### PR TITLE
Add calibration binary sensors for wand

### DIFF
--- a/custom_components/magic_caster_wand/__init__.py
+++ b/custom_components/magic_caster_wand/__init__.py
@@ -73,8 +73,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         name=f"{DOMAIN}_buttons_{identifier}",
     )
 
+    calibration_coordinator: DataUpdateCoordinator[dict[str, bool]] = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name=f"{DOMAIN}_calibration_{identifier}",
+    )
+
     # Register coordinators with device for BLE callbacks
-    mcw.register_coordinator(spell_coordinator, battery_coordinator, buttons_coordinator)
+    mcw.register_coordinator(spell_coordinator, battery_coordinator, buttons_coordinator, calibration_coordinator)
 
     # Perform first refresh
     await coordinator.async_config_entry_first_refresh()
@@ -87,6 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "spell_coordinator": spell_coordinator,
         "battery_coordinator": battery_coordinator,
         "buttons_coordinator": buttons_coordinator,
+        "calibration_coordinator": calibration_coordinator,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/magic_caster_wand/manifest.json
+++ b/custom_components/magic_caster_wand/manifest.json
@@ -19,5 +19,5 @@
   "documentation": "https://www.github.com/eigger/hass-magic_caster_wand",
   "issue_tracker": "https://www.github.com/eigger/hass-magic_caster_wand/issues",
   "iot_class": "local_polling",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }

--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -43,12 +43,14 @@ class McwDevice:
         self._coordinator_spell = None
         self._coordinator_battery = None
         self._coordinator_buttons = None
+        self._coordinator_calibration = None
 
-    def register_coordinator(self, cn_spell, cn_battery, cn_buttons) -> None:
-        """Register coordinators for spell, battery, and button updates."""
+    def register_coordinator(self, cn_spell, cn_battery, cn_buttons, cn_calibration=None) -> None:
+        """Register coordinators for spell, battery, button, and calibration updates."""
         self._coordinator_spell = cn_spell
         self._coordinator_battery = cn_battery
         self._coordinator_buttons = cn_buttons
+        self._coordinator_calibration = cn_calibration
 
     def _callback_spell(self, data: str) -> None:
         """Handle spell detection callback."""
@@ -64,6 +66,11 @@ class McwDevice:
         """Handle button state update callback."""
         if self._coordinator_buttons:
             self._coordinator_buttons.async_set_updated_data(data)
+
+    def _callback_calibration(self, data: dict[str, bool]) -> None:
+        """Handle calibration state update callback."""
+        if self._coordinator_calibration:
+            self._coordinator_calibration.async_set_updated_data(data)
 
     def is_connected(self) -> bool:
         """Check if the device is currently connected."""
@@ -95,7 +102,7 @@ class McwDevice:
             if not self._data.identifier:
                 self._data.identifier = ble_device.address.replace(":", "")[-8:]
             self._mcw = McwClient(self.client)
-            self._mcw.register_callback(self._callback_spell, self._callback_battery, self._callback_buttons)
+            self._mcw.register_callback(self._callback_spell, self._callback_battery, self._callback_buttons, self._callback_calibration)
             await self._mcw.start_notify()
             if not self.model:
                 self.model = await self._mcw.get_wand_no()


### PR DESCRIPTION
Introduces calibration binary sensors to track button and IMU calibration states. Updates BLE client and parser to handle calibration notifications and callbacks, and registers a new calibration coordinator. Bumps integration version to 1.1.2.