### PR TITLE
Update GitHub repository links

### DIFF
--- a/custom_components/magic_caster_wand/manifest.json
+++ b/custom_components/magic_caster_wand/manifest.json
@@ -16,11 +16,11 @@
     "bluetooth",
     "bluetooth_adapters"
   ],
-  "documentation": "https://www.github.com/eigger/hass-magic_caster_wand",
+  "documentation": "https://www.github.com/eigger/hass-magic-caster-wand",
   "iot_class": "local_polling",
-  "issue_tracker": "https://www.github.com/eigger/hass-magic_caster_wand/issues",
+  "issue_tracker": "https://www.github.com/eigger/hass-magic-caster-wand/issues",
   "requirements": [
     "numpy"
   ],
-  "version": "1.2.11"
+  "version": "1.2.12"
 }


### PR DESCRIPTION
The repository links defined manifest.json lead to a 404 page on GitHub.