### PR TITLE
Fixes services / Adds Send Macro service / Adds Magic Caster Box functionality

### DIFF
--- a/custom_components/magic_caster_wand/__init__.py
+++ b/custom_components/magic_caster_wand/__init__.py
@@ -158,19 +158,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Handle execution of send_frame service."""
         commands = call.data.get("commands", [])
         device_ids = call.data.get("device_id", [])
-
-        # Normalize device_id input
         if isinstance(device_ids, str):
             device_ids = [device_ids]
-
         for device_id in device_ids:
             entry_id = await get_entry_id_from_device(hass, device_id)
             if entry_id and entry_id in hass.data[DOMAIN]:
                 device: McwDevice = hass.data[DOMAIN][entry_id]["mcw"]
-
-                # Pass commands directly to the device
                 await device.send_macro_parse(commands)
-
 
     async def handle_clear_leds(call: ServiceCall) -> None:
         """Handle execution of clear_leds service."""

--- a/custom_components/magic_caster_wand/__init__.py
+++ b/custom_components/magic_caster_wand/__init__.py
@@ -154,6 +154,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 device: McwDevice = hass.data[DOMAIN][entry_id]["mcw"]
                 await device.set_led(group, rgb[0], rgb[1], rgb[2], duration)
 
+    async def handle_send_macro(call: ServiceCall) -> None:
+        """Handle execution of send_frame service."""
+        commands = call.data.get("commands", [])
+        device_ids = call.data.get("device_id", [])
+
+        # Normalize device_id input
+        if isinstance(device_ids, str):
+            device_ids = [device_ids]
+
+        for device_id in device_ids:
+            entry_id = await get_entry_id_from_device(hass, device_id)
+            if entry_id and entry_id in hass.data[DOMAIN]:
+                device: McwDevice = hass.data[DOMAIN][entry_id]["mcw"]
+
+                # Pass commands directly to the device
+                await device.send_macro_parse(commands)
+
+
     async def handle_clear_leds(call: ServiceCall) -> None:
         """Handle execution of clear_leds service."""
         device_ids = call.data.get("device_id", [])
@@ -189,6 +207,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.services.async_register(DOMAIN, "clear_leds", handle_clear_leds)
     if not hass.services.has_service(DOMAIN, "play_spell"):
         hass.services.async_register(DOMAIN, "play_spell", handle_play_spell)
+    if not hass.services.has_service(DOMAIN, "send_macro"):
+        hass.services.async_register(DOMAIN, "send_macro", handle_send_macro)        
 
     return True
 

--- a/custom_components/magic_caster_wand/__init__.py
+++ b/custom_components/magic_caster_wand/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, CONF_TFLITE_URL, DEFAULT_TFLITE_URL, CONF_SPELL_TIMEOUT, DEFAULT_SPELL_TIMEOUT
-from .mcw_ble import BLEData, McwDevice, LedGroup
+from .mcw_ble import BLEData, McwDevice, McbDevice, LedGroup, LIDSTATE
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.TEXT, Platform.SELECT, Platform.BINARY_SENSOR, Platform.BUTTON, Platform.CAMERA]
 
@@ -29,6 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     address = entry.unique_id
+    device_type = entry.data.get("device_type", "mcw")
     assert address is not None
 
     await close_stale_connections_by_address(address)
@@ -43,7 +44,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Create device instance
     tflite_url = entry.options.get(CONF_TFLITE_URL, entry.data.get(CONF_TFLITE_URL, DEFAULT_TFLITE_URL))
     spell_timeout = entry.options.get(CONF_SPELL_TIMEOUT, entry.data.get(CONF_SPELL_TIMEOUT, DEFAULT_SPELL_TIMEOUT))
-    mcw = McwDevice(address, tflite_url=tflite_url, spell_timeout=spell_timeout)
+    if device_type == "mcb":
+        device = McbDevice(address)
+    else:
+        device = McwDevice(address, tflite_url=tflite_url, spell_timeout=spell_timeout)
+
     identifier = address.replace(":", "")[-8:]
 
     # Create coordinators with unique names for debugging
@@ -51,40 +56,60 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         _LOGGER,
         name=f"{DOMAIN}_main_{identifier}",
-        update_method=partial(_async_update_method, hass, entry, mcw),
+        update_method=partial(_async_update_method, hass, entry, device),
         update_interval=timedelta(
             seconds=float(entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
         ),
     )
 
-    spell_coordinator: DataUpdateCoordinator[str] = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=f"{DOMAIN}_spell_{identifier}",
-    )
+    if device_type == "mcw":
+        spell_coordinator: DataUpdateCoordinator[str] = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_spell_{identifier}",
+        )
+
+        buttons_coordinator: DataUpdateCoordinator[dict[str, bool]] = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_buttons_{identifier}",
+        )        
+            
+        calibration_coordinator: DataUpdateCoordinator[dict[str, bool]] = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_calibration_{identifier}",
+        )
+
+        imu_coordinator: DataUpdateCoordinator[list[dict[str, float]]] = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_imu_{identifier}",
+        )
+
+    elif device_type == "mcb":
+        lid_coordinator: DataUpdateCoordinator[bool] = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_lid_{identifier}",
+        )
+
+        usb_plugged_coordinator: DataUpdateCoordinator[bool] = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_usb_plugged_{identifier}",
+        )
+
+        wand_coordinator: DataUpdateCoordinator[bool] = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_wand_present_{identifier}",
+        )
 
     battery_coordinator: DataUpdateCoordinator[float] = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name=f"{DOMAIN}_battery_{identifier}",
-    )
-
-    buttons_coordinator: DataUpdateCoordinator[dict[str, bool]] = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=f"{DOMAIN}_buttons_{identifier}",
-    )
-
-    calibration_coordinator: DataUpdateCoordinator[dict[str, bool]] = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=f"{DOMAIN}_calibration_{identifier}",
-    )
-
-    imu_coordinator: DataUpdateCoordinator[list[dict[str, float]]] = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=f"{DOMAIN}_imu_{identifier}",
     )
 
     connection_coordinator: DataUpdateCoordinator[bool] = DataUpdateCoordinator(
@@ -96,20 +121,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     connection_coordinator.async_set_updated_data(False)
 
     # Register coordinators with device for BLE callbacks
-    mcw.register_coordinator(spell_coordinator, battery_coordinator, buttons_coordinator, calibration_coordinator, imu_coordinator, connection_coordinator)
+    if device_type == "mcw":
+        device.register_coordinator(spell_coordinator, battery_coordinator, buttons_coordinator, calibration_coordinator, imu_coordinator, connection_coordinator)
+    elif device_type == "mcb":
+        device.register_coordinator(battery_coordinator, lid_coordinator, usb_plugged_coordinator, wand_coordinator, connection_coordinator)
 
     # Store data for platforms
-    hass.data[DOMAIN][entry.entry_id] = {
-        "address": address,
-        "mcw": mcw,
-        "coordinator": coordinator,
-        "spell_coordinator": spell_coordinator,
-        "battery_coordinator": battery_coordinator,
-        "buttons_coordinator": buttons_coordinator,
-        "calibration_coordinator": calibration_coordinator,
-        "imu_coordinator": imu_coordinator,
-        "connection_coordinator": connection_coordinator,
-    }
+    if device_type == "mcw":
+        hass.data[DOMAIN][entry.entry_id] = {
+            "address": address,
+            "device": device,
+            "type": device_type,
+            "coordinator": coordinator,
+            "spell_coordinator": spell_coordinator,
+            "battery_coordinator": battery_coordinator,
+            "buttons_coordinator": buttons_coordinator,
+            "calibration_coordinator": calibration_coordinator,
+            "imu_coordinator": imu_coordinator,
+            "connection_coordinator": connection_coordinator,
+        }
+    elif device_type == "mcb":
+        hass.data[DOMAIN][entry.entry_id] = {
+            "address": address,
+            "device": device,
+            "type": device_type,
+            "coordinator": coordinator,
+            "battery_coordinator": battery_coordinator,
+            "lid_coordinator": lid_coordinator,
+            "usb_plugged_coordinator": usb_plugged_coordinator,
+            "wand_coordinator": wand_coordinator,
+            "connection_coordinator": connection_coordinator,
+        }
 
     # Perform first refresh (best-effort). If it fails, entities will remain unavailable
     # until a later successful update.
@@ -136,7 +178,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for device_id in device_ids:
             entry_id = await get_entry_id_from_device(hass, device_id)
             if entry_id and entry_id in hass.data[DOMAIN]:
-                device: McwDevice = hass.data[DOMAIN][entry_id]["mcw"]
+                device: McwDevice | McbDevice = hass.data[DOMAIN][entry_id]["device"]
                 await device.buzz(duration)
 
     async def handle_set_led(call: ServiceCall) -> None:
@@ -151,7 +193,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for device_id in device_ids:
             entry_id = await get_entry_id_from_device(hass, device_id)
             if entry_id and entry_id in hass.data[DOMAIN]:
-                device: McwDevice = hass.data[DOMAIN][entry_id]["mcw"]
+                device: McwDevice | McbDevice = hass.data[DOMAIN][entry_id]["device"]
                 await device.set_led(group, rgb[0], rgb[1], rgb[2], duration)
 
     async def handle_send_macro(call: ServiceCall) -> None:
@@ -163,7 +205,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for device_id in device_ids:
             entry_id = await get_entry_id_from_device(hass, device_id)
             if entry_id and entry_id in hass.data[DOMAIN]:
-                device: McwDevice = hass.data[DOMAIN][entry_id]["mcw"]
+                device: McwDevice | McbDevice = hass.data[DOMAIN][entry_id]["device"]
                 await device.send_macro_parse(commands)
 
     async def handle_clear_leds(call: ServiceCall) -> None:
@@ -174,7 +216,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for device_id in device_ids:
             entry_id = await get_entry_id_from_device(hass, device_id)
             if entry_id and entry_id in hass.data[DOMAIN]:
-                device: McwDevice = hass.data[DOMAIN][entry_id]["mcw"]
+                device: McwDevice | McbDevice = hass.data[DOMAIN][entry_id]["device"]
                 await device.clear_leds()
 
     async def handle_play_spell(call: ServiceCall) -> None:
@@ -186,7 +228,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for device_id in device_ids:
             entry_id = await get_entry_id_from_device(hass, device_id)
             if entry_id and entry_id in hass.data[DOMAIN]:
-                device: McwDevice = hass.data[DOMAIN][entry_id]["mcw"]
+                device: McwDevice | McbDevice = hass.data[DOMAIN][entry_id]["device"]
                 # Use helper for more robust spell matching
                 from .mcw_ble import get_spell_macro
                 macro = get_spell_macro(spell_name)
@@ -226,7 +268,7 @@ async def _async_update_method(
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    mcw: McwDevice = hass.data[DOMAIN][entry.entry_id]["mcw"]
+    mcw: McwDevice | McbDevice = hass.data[DOMAIN][entry.entry_id]["device"]
     await mcw.disconnect()
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):

--- a/custom_components/magic_caster_wand/binary_sensor.py
+++ b/custom_components/magic_caster_wand/binary_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN, MANUFACTURER
-from .mcw_ble import BLEData
+from .mcw_ble import McbDevice, McwDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,25 +35,35 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Magic Caster Wand BLE button binary sensors."""
     data = hass.data[DOMAIN][entry.entry_id]
-    buttons_coordinator: DataUpdateCoordinator[dict[str, bool]] = data["buttons_coordinator"]
-    connection_coordinator: DataUpdateCoordinator[bool] = data["connection_coordinator"]
     address = data["address"]
-    mcw = data["mcw"]
+    device = data["device"]
+    device_type = data["type"]
+    connection_coordinator: DataUpdateCoordinator[bool] = data["connection_coordinator"]
 
-    entities = [
-        McwButtonBinarySensor(
-            address=address,
-            mcw=mcw,
-            coordinator=buttons_coordinator,
-            connection_coordinator=connection_coordinator,
-            button_key=button["key"],
-            button_name=button["name"]
-        )
-        for button in BUTTONS
-    ]
+    entities = []
+    if device_type == "mcw":
+        buttons_coordinator: DataUpdateCoordinator[dict[str, bool]] = data["buttons_coordinator"]
+        entities.extend([
+            McwButtonBinarySensor(
+                address=address,
+                mcw=device,
+                coordinator=buttons_coordinator,
+                connection_coordinator=connection_coordinator,
+                button_key=button["key"],
+                button_name=button["name"]
+            )
+            for button in BUTTONS
+        ])
+
+    elif device_type == "mcb":
+        entities.extend([
+            McbLidBinarySensor(address, device, data["lid_coordinator"], connection_coordinator),
+            McbUSBPluggedBinarySensor(address, device, data["usb_plugged_coordinator"], connection_coordinator),
+            McbWandPresentBinarySensor(address, device, data["wand_coordinator"], connection_coordinator),
+        ])
 
     # Add connection status binary sensor
-    entities.append(McwConnectionBinarySensor(address, mcw, connection_coordinator))
+    entities.append(McwConnectionBinarySensor(address, device, connection_coordinator))
 
     async_add_entities(entities)
 
@@ -152,14 +162,14 @@ class McwConnectionBinarySensor(
     def __init__(
         self,
         address: str,
-        mcw,
+        device: McwDevice | McbDevice,
         connection_coordinator: DataUpdateCoordinator[bool],
     ) -> None:
         """Initialize the connection binary sensor."""
         CoordinatorEntity.__init__(self, connection_coordinator)
         
         self._address = address
-        self._mcw = mcw
+        self._device = device
         self._identifier = address.replace(":", "")[-8:]
         
         self._attr_name = "Connected"
@@ -168,11 +178,12 @@ class McwConnectionBinarySensor(
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
+        device_label = "Wand" if isinstance(self._device, McwDevice) else "Box"
         return DeviceInfo(
             connections={(CONNECTION_BLUETOOTH, self._address)},
-            name=f"Magic Caster Wand {self._identifier}",
+            name=f"Magic Caster {device_label} {self._identifier}",
             manufacturer=MANUFACTURER,
-            model=self._mcw.model if self._mcw else None,
+            model=self._device.model if self._device else None,
         )
 
     @property
@@ -184,3 +195,101 @@ class McwConnectionBinarySensor(
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self.async_write_ha_state()
+        
+class McbBaseBinarySensor(CoordinatorEntity[DataUpdateCoordinator[bool]], BinarySensorEntity):
+    """Base class for Magic Caster Box binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, address, device, coordinator, connection_coordinator, name, key):
+        CoordinatorEntity.__init__(self, coordinator)
+
+        self._address = address
+        self._device = device
+        self._identifier = address.replace(":", "")[-8:]
+        self._attr_unique_id = f"{address}_{key}"
+        self._attr_name = name
+        self._key = key
+        self._connection_coordinator = connection_coordinator
+
+    async def async_added_to_hass(self) -> None:
+        """Register connection coordinator listener."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._connection_coordinator.async_add_listener(
+                self._handle_connection_update
+            )
+        )
+
+    @callback
+    def _handle_connection_update(self) -> None:
+        """Handle connection state changes."""
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+            name=f"Magic Caster Box {self._identifier}",
+            manufacturer=MANUFACTURER,
+            model=self._device.model if self._device else None,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._connection_coordinator.data is True
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is true."""
+        try:
+            return bool(self.coordinator.data)
+        except Exception as err:
+            _LOGGER.error("Error reading state: %s", err)
+            return False
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()    
+        
+class McbLidBinarySensor(McbBaseBinarySensor):
+    """Magic Caster Box lid open/close sensor."""
+
+    def __init__(self, address, device, coordinator, connection_coordinator):
+        super().__init__(
+            address=address,
+            device=device,
+            coordinator=coordinator,
+            connection_coordinator=connection_coordinator,
+            name="Lid",
+            key="lid",
+        )
+
+class McbUSBPluggedBinarySensor(McbBaseBinarySensor):
+    """Magic Caster Box USB plugged-in sensor."""
+
+    def __init__(self, address, device, coordinator, connection_coordinator):
+        super().__init__(
+            address=address,
+            device=device,
+            coordinator=coordinator,
+            connection_coordinator=connection_coordinator,
+            name="USB Plugged",
+            key="usb_plugged",
+        )
+
+class McbWandPresentBinarySensor(McbBaseBinarySensor):
+    """Magic Caster Box wand-present sensor."""
+
+    def __init__(self, address, device, coordinator, connection_coordinator):
+        super().__init__(
+            address=address,
+            device=device,
+            coordinator=coordinator,
+            connection_coordinator=connection_coordinator,
+            name="Wand",
+            key="wand_present",
+        )

--- a/custom_components/magic_caster_wand/button.py
+++ b/custom_components/magic_caster_wand/button.py
@@ -23,15 +23,17 @@ async def async_setup_entry(
     """Set up the Magic Caster Wand BLE buttons."""
     data = hass.data[DOMAIN][entry.entry_id]
     address = data["address"]
-    mcw = data["mcw"]
+    device = data["device"]
+    device_type = data["type"]
     coordinator = data["coordinator"]
-    calibration_coordinator = data["calibration_coordinator"]
-    connection_coordinator = data["connection_coordinator"]
 
-    async_add_entities([
-        McwButtonCalibration(address, mcw, coordinator, calibration_coordinator, connection_coordinator),
-        McwImuCalibration(address, mcw, coordinator, calibration_coordinator, connection_coordinator),
-    ])
+    if device_type == "mcw":
+        calibration_coordinator = data["calibration_coordinator"]
+        connection_coordinator = data["connection_coordinator"]
+        async_add_entities([
+            McwButtonCalibration(address, device, coordinator, calibration_coordinator, connection_coordinator),
+            McwImuCalibration(address, device, coordinator, calibration_coordinator, connection_coordinator),
+        ])
 
 
 class McwBaseCalibrationButton(CoordinatorEntity[DataUpdateCoordinator[BLEData]], ButtonEntity):

--- a/custom_components/magic_caster_wand/camera.py
+++ b/custom_components/magic_caster_wand/camera.py
@@ -33,13 +33,15 @@ async def async_setup_entry(
     """Set up the Magic Caster Wand BLE camera."""
     data = hass.data[DOMAIN][entry.entry_id]
     address = data["address"]
-    mcw = data["mcw"]
-    imu_coordinator = data["imu_coordinator"]
-    buttons_coordinator = data["buttons_coordinator"]
-    spell_coordinator = data["spell_coordinator"]
-    connection_coordinator = data["connection_coordinator"]
+    device = data["device"]
+    device_type = data["type"]
 
-    async_add_entities([McwSpellCamera(hass, address, mcw, imu_coordinator, buttons_coordinator, spell_coordinator, connection_coordinator)])
+    if device_type == "mcw":
+        imu_coordinator = data["imu_coordinator"]
+        buttons_coordinator = data["buttons_coordinator"]
+        spell_coordinator = data["spell_coordinator"]
+        connection_coordinator = data["connection_coordinator"]
+        async_add_entities([McwSpellCamera(hass, address, device, imu_coordinator, buttons_coordinator, spell_coordinator, connection_coordinator)])
 
 
 class McwSpellCamera(CoordinatorEntity, Camera):

--- a/custom_components/magic_caster_wand/config_flow.py
+++ b/custom_components/magic_caster_wand/config_flow.py
@@ -6,7 +6,9 @@ from collections.abc import Mapping
 import dataclasses
 from typing import Any
 
-from .mcw_ble import McwBluetoothDeviceData as DeviceData
+from .mcw_ble import McwBluetoothDeviceData, McbBluetoothDeviceData
+DEVICE_TYPES = [McwBluetoothDeviceData, McbBluetoothDeviceData]
+
 import voluptuous as vol
 
 from homeassistant.components import onboarding
@@ -26,10 +28,10 @@ class Discovery:
 
     title: str
     discovery_info: BluetoothServiceInfoBleak
-    device: DeviceData
+    device: McwBluetoothDeviceData  | McbBluetoothDeviceData
 
 
-def _title(discovery_info: BluetoothServiceInfoBleak, device: DeviceData) -> str:
+def _title(discovery_info: BluetoothServiceInfoBleak, device: McwBluetoothDeviceData | McbBluetoothDeviceData) -> str:
     return device.title or device.get_device_name() or discovery_info.name
 
 
@@ -49,7 +51,7 @@ class McwConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._discovery_info: BluetoothServiceInfoBleak | None = None
-        self._discovered_device: DeviceData | None = None
+        self._discovered_device: McwBluetoothDeviceData | McbBluetoothDeviceData | None = None
         self._discovered_devices: dict[str, Discovery] = {}
 
     async def async_step_bluetooth(
@@ -58,17 +60,16 @@ class McwConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the bluetooth discovery step."""
         await self.async_set_unique_id(discovery_info.address)
         self._abort_if_unique_id_configured()
-        device = DeviceData()
+        for device_cls in DEVICE_TYPES:
+            device = device_cls()
+            if device.supported(discovery_info):
+                title = _title(discovery_info, device)
+                self.context["title_placeholders"] = {"name": title}
+                self._discovery_info = discovery_info
+                self._discovered_device = device
+                return await self.async_step_bluetooth_confirm()
 
-        if not device.supported(discovery_info):
-            return self.async_abort(reason="not_supported")
-
-        title = _title(discovery_info, device)
-        self.context["title_placeholders"] = {"name": title}
-        self._discovery_info = discovery_info
-        self._discovered_device = device
-
-        return await self.async_step_bluetooth_confirm()
+        return self.async_abort(reason="not_supported")
 
     async def async_step_bluetooth_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -105,13 +106,15 @@ class McwConfigFlow(ConfigFlow, domain=DOMAIN):
             address = discovery_info.address
             if address in current_addresses or address in self._discovered_devices:
                 continue
-            device = DeviceData()
-            if device.supported(discovery_info):
-                self._discovered_devices[address] = Discovery(
-                    title=_title(discovery_info, device),
-                    discovery_info=discovery_info,
-                    device=device,
-                )
+            for device_cls in DEVICE_TYPES:
+                device = device_cls()
+                if device.supported(discovery_info):
+                    self._discovered_devices[address] = Discovery(
+                        title=_title(discovery_info, device),
+                        discovery_info=discovery_info,
+                        device=device,
+                    )
+                    break
 
         if not self._discovered_devices:
             return self.async_abort(reason="no_devices_found")
@@ -129,7 +132,7 @@ class McwConfigFlow(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle a flow initialized by a reauth event."""
-        device: DeviceData = entry_data["device"]
+        device: McwBluetoothDeviceData | McbBluetoothDeviceData = entry_data["device"]
         self._discovered_device = device
 
         self._discovery_info = device.last_service_info
@@ -143,6 +146,9 @@ class McwConfigFlow(ConfigFlow, domain=DOMAIN):
         data: dict[str, Any] = {}
         if bindkey:
             data["bindkey"] = bindkey
+
+        if self._discovered_device is not None:
+            data["device_type"] = self._discovered_device.device_type
 
         if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(

--- a/custom_components/magic_caster_wand/manifest.json
+++ b/custom_components/magic_caster_wand/manifest.json
@@ -6,6 +6,10 @@
       "connectable": true,
       "local_name": "MCW-*",
       "service_uuid": "0000180a-0000-1000-8000-00805f9b34fb"
+    },
+    {
+      "connectable": true,
+      "local_name": "MCB-*"
     }
   ],
   "codeowners": [

--- a/custom_components/magic_caster_wand/mcw_ble/__init__.py
+++ b/custom_components/magic_caster_wand/mcw_ble/__init__.py
@@ -19,15 +19,19 @@ def _running_imuvisualizer_via_m() -> bool:
 if _running_imuvisualizer_via_m():
     __all__ = []
 else:
-    from .parser import McwDevice, BLEData, McwBluetoothDeviceData
+    from .parser import McwDevice, McbDevice, BLEData, McwBluetoothDeviceData, McbBluetoothDeviceData
     from .mcw import LedGroup
+    from .mcb import LIDSTATE
     from .macros import Macro, get_spell_macro
 
     __all__ = [
         "McwDevice",
+        "McbDevice",
         "BLEData",
         "McwBluetoothDeviceData",
+        "McbBluetoothDeviceData",
         "LedGroup",
         "Macro",
         "get_spell_macro",
+        "LIDSTATE",
     ]

--- a/custom_components/magic_caster_wand/mcw_ble/mcb.py
+++ b/custom_components/magic_caster_wand/mcw_ble/mcb.py
@@ -152,7 +152,6 @@ class McbClient:
         """Initialize the client."""
         self.client = client
         self.callback_battery: Callable[[float], None] | None = None
-        self.callback_lid_status: Callable[[LIDSTATE], None]
         self.callback_lid: Callable[[LIDNOTIFY], None] 
         self.callback_wand: Callable[[WANDNOTIFY], None]
         self.callback_charge: Callable[[CHARGENOTIFY], None]
@@ -175,7 +174,6 @@ class McbClient:
     def register_callback(
             self,
             battery_cb: Callable[[float], None],
-            lid_status_cb: Callable[[LIDSTATE], None],
             lid_cb: Callable[[LIDNOTIFY], None],
             wand_cb: Callable[[WANDNOTIFY], None],
             charge_cb: Callable[[CHARGENOTIFY], None]
@@ -183,7 +181,6 @@ class McbClient:
         """Register callbacks for spell, battery, button, and calibration notifications."""
         self.callback_battery = battery_cb
 
-        self.callback_lid_status = lid_status_cb
         self.callback_lid = lid_cb
         self.callback_wand = wand_cb
         self.callback_charge = charge_cb        
@@ -486,9 +483,6 @@ class McbClient:
 
         state = mapping.get(data[1], LIDSTATE.UNKNOWN)
         _LOGGER.debug(f"Lid/Wand combined status: {state.name}")
-
-        if self.callback_lid_status:
-            self.callback_lid_status(state)
 
     def _parse_lid_notify(self, data: bytearray) -> None:
         if len(data) < 2:

--- a/custom_components/magic_caster_wand/mcw_ble/mcb.py
+++ b/custom_components/magic_caster_wand/mcw_ble/mcb.py
@@ -1,0 +1,522 @@
+    # mcb_ble.py
+"""BLE client for Magic Caster Wand Box communication."""
+
+from __future__ import annotations
+
+import logging
+import struct
+import asyncio
+from asyncio import Event, sleep, wait_for
+from bleak import BleakClient, BleakError
+from .macros import LedGroup, Macro
+from typing import Any, Callable, TypeVar
+
+from enum import Enum, IntEnum, auto
+
+SERVICE_UUID = "57420001-587e-48a0-974c-54686f72c577"
+COMMAND_UUID = "57420002-587e-48a0-974c-54686f72c577"
+NOTIFY_UUID = "57420003-587e-48a0-974c-54686f72c577"
+BATTERY_UUID = "00002a19-0000-1000-8000-00805f9b34fb"
+
+class LIDSTATE(Enum):
+    LID_ON_NO_WAND = auto()
+    LID_OFF_NO_WAND = auto()
+    LID_ON_WAND = auto()
+    LID_OFF_WAND = auto()
+    UNKNOWN = auto()
+
+class LIDNOTIFY(IntEnum):
+    LID_REMOVED = 0    
+    LID_ON = 1
+
+
+class WANDNOTIFY(IntEnum):
+    WAND_REMOVED = 0
+    WAND_PLUGGED = 1
+
+class CHARGENOTIFY(IntEnum):
+    CHARGE_UNPLUGGED = 0
+    CHARGE_PLUGGED = 1
+
+# Message packet IDs from APK
+class MESSAGEIDS:
+    FIRMWARE_VERSION_READ = 0x00 
+    """FirmwareVersionReadMessage.kt"""
+    CHALLENGE = 0x01
+    """ChallengeMessage.kt"""
+    PAIR_WITH_ME = 0x03
+    """PairWithMeMessage.kt"""
+    WAND_ADDRESS_READ = 0x09
+    """BoxAddressReadMessage.kt"""
+    WAND_PRODUCT_INFORMATION_READ = 0x0E
+    """WandProductInfoReadMessage.kt"""
+    IMUFLAG_SET = 0x30
+    """IMUFlagMessage.kt"""
+    IMUFLAG_RESET = 0x31
+    """IMUFlagMessage.kt"""
+    LIGHT_CONTROL_CLEAR_ALL = 0x40
+    """LightControlClearAllMessage.kt"""
+    LIGHT_CONTROL_SET_LED = 0x42
+    """LightControlSetMessage.kt"""
+    BUTTON_SET_THRESHOLD = 0xDC
+    """ButtonSetThresholdMessage.kt"""
+    BUTTON_READ_THRESHOLD = 0xDD
+    """ButtonReadThresholdMessage.kt"""
+    BUTTON_CALIBRATION_BASELINE = 0xFB
+    """ButtonCalibrationBaselineMessage.kt"""
+    IMU_CALIBRATION = 0xFC
+    """IMUCalibrationMessage.kt"""
+    FACTORY_UNLOCK = 0xFE
+    """FactoryUnlockMessage.kt"""
+
+    LID_STATUS_SEND = 0x10      # Combined lid/wand status request
+    LID_NOTIFY_REQUEST = 0x11   # Request lid notifications
+    WAND_NOTIFY_REQUEST = 0x12  # Request wand plug/unplug notifications
+    CHARGE_NOTIFY_REQUEST = 0x13     
+
+# Response packet IDs from APK
+class RESPONSEIDS:
+    FIRMWARE_VERSION = 0x00
+    """FirmwareVersionResponseMessage.kt"""
+    CHALLENGE = 0x01
+    """ChallengeResponseMessage.kt"""
+    PONG = 0x02
+    """PongResponseMessage.kt"""
+    WAND_ADDRESS = 0x09
+    """BoxAddressResponseMessage.kt"""
+    BUTTON_PAYLOAD = 0x10
+    """ButtonPayloadMessage.kt"""
+    WAND_PRODUCT_INFORMATION = 0x0E
+    """WandProductInfoResponseMessage.kt"""
+    SPELL_CAST = 0x24
+    """???"""
+    IMU_PAYLOAD = 0x2C
+    """IMUPayloadMessage.kt"""
+    BUTTON_READ_THRESHOLD = 0xDD
+    """ButtonReadThresholdResponseMessage.kt"""
+    BUTTON_CALIBRATION_BASELINE = 0xFB
+    """ButtonCalibrationBaselineResponseMessage.kt"""
+    IMU_CALIBRATION = 0xFC
+    """IMUCalibrationResponseMessage.kt"""
+
+    LID_STATUS = 0x10
+    LID_NOTIFY = 0x11
+    WAND_NOTIFY = 0x12
+    CHARGE_NOTIFY = 0x13    
+
+MESSAGE_TO_RESPONSE_MAP: dict[int, int] = {
+    MESSAGEIDS.WAND_ADDRESS_READ: RESPONSEIDS.WAND_ADDRESS,
+    MESSAGEIDS.BUTTON_CALIBRATION_BASELINE: RESPONSEIDS.BUTTON_CALIBRATION_BASELINE,
+    MESSAGEIDS.CHALLENGE: RESPONSEIDS.CHALLENGE,
+    MESSAGEIDS.FIRMWARE_VERSION_READ: RESPONSEIDS.FIRMWARE_VERSION,
+    MESSAGEIDS.IMU_CALIBRATION: RESPONSEIDS.IMU_CALIBRATION,
+    MESSAGEIDS.WAND_PRODUCT_INFORMATION_READ: RESPONSEIDS.WAND_PRODUCT_INFORMATION,
+    MESSAGEIDS.LID_STATUS_SEND: RESPONSEIDS.LID_STATUS,
+    MESSAGEIDS.LID_NOTIFY_REQUEST: RESPONSEIDS.LID_NOTIFY,
+    MESSAGEIDS.WAND_NOTIFY_REQUEST: RESPONSEIDS.WAND_NOTIFY,
+    MESSAGEIDS.CHARGE_NOTIFY_REQUEST: RESPONSEIDS.CHARGE_NOTIFY,    
+}
+
+_LOGGER = logging.getLogger(__name__)
+
+class BleakCharacteristicMissing(BleakError):
+    """Raised when a characteristic is missing."""
+
+class BleakServiceMissing(BleakError):
+    """Raised when a service is missing."""
+
+WrapFuncType = TypeVar("WrapFuncType", bound=Callable[..., Any])
+
+def disconnect_on_missing_services(func: WrapFuncType) -> WrapFuncType:
+    """Decorator to handle missing services by disconnecting."""
+
+    async def wrapper(self, *args, **kwargs):
+        try:
+            return await func(self, *args, **kwargs)
+        except (BleakServiceMissing, BleakCharacteristicMissing):
+            try:
+                if self.client.is_connected:
+                    await self.client.clear_cache()
+                    await self.client.disconnect()
+            except Exception:
+                pass
+            raise
+
+    return wrapper  # type: ignore
+
+
+class McbClient:
+    """BLE client for communicating with Magic Caster Box."""
+
+    def __init__(self, client: BleakClient) -> None:
+        """Initialize the client."""
+        self.client = client
+        self.callback_battery: Callable[[float], None] | None = None
+        self.callback_lid_status: Callable[[LIDSTATE], None]
+        self.callback_lid: Callable[[LIDNOTIFY], None] 
+        self.callback_wand: Callable[[WANDNOTIFY], None]
+        self.callback_charge: Callable[[CHARGENOTIFY], None]
+        self.lock = asyncio.Lock()
+
+        self._box_address: str | None = None
+        self._waiting_cmd_event: Event = Event()
+        self._waiting_for_msg_id: int | None = None
+        self._box_challenge: int | None = None
+        self._box_device_id: str | None = None
+        self._box_firmware_version: str | None = None
+        self._box_serial_number: str | None = None
+        self._box_sku: str | None = None
+        self._box_type: str | None = None
+        
+    def is_connected(self) -> bool:
+        """Check if client is connected."""
+        return self.client.is_connected
+
+    def register_callback(
+            self,
+            battery_cb: Callable[[float], None],
+            lid_status_cb: Callable[[LIDSTATE], None],
+            lid_cb: Callable[[LIDNOTIFY], None],
+            wand_cb: Callable[[WANDNOTIFY], None],
+            charge_cb: Callable[[CHARGENOTIFY], None]
+    ) -> None:
+        """Register callbacks for spell, battery, button, and calibration notifications."""
+        self.callback_battery = battery_cb
+
+        self.callback_lid_status = lid_status_cb
+        self.callback_lid = lid_cb
+        self.callback_wand = wand_cb
+        self.callback_charge = charge_cb        
+
+    @disconnect_on_missing_services
+    async def start_notify(self) -> None:
+        """Start receiving notifications."""
+        await self.client.start_notify(NOTIFY_UUID, self._handler)
+        await self.client.start_notify(BATTERY_UUID, self._handler_battery)
+        await sleep(1.0)
+
+        try:
+            # Query initial battery level
+            battery_data = await self.client.read_gatt_char(BATTERY_UUID)
+            self._handler_battery(None, bytearray(battery_data))
+            await self.request_box_notifications()
+            await self.request_charge_notifications()
+            await self.request_lid_notifications()
+
+        except Exception as err:
+            _LOGGER.warning("Error reading initial battery level: %s", err)
+
+    @disconnect_on_missing_services
+    async def stop_notify(self) -> None:
+        """Stop receiving notifications."""
+        try:
+            await self.client.stop_notify(NOTIFY_UUID)
+            await self.client.stop_notify(BATTERY_UUID)
+        except Exception as err:
+            _LOGGER.debug("Error stopping notifications: %s", err)
+
+    @disconnect_on_missing_services
+    async def write(self, uuid: str, data: bytes, response: bool = False) -> None:
+        """Write data to the specified characteristic."""
+        _LOGGER.debug("Write UUID=%s data=%s", uuid, data.hex())
+        await self.client.write_gatt_char(uuid, data, response)
+
+    def _handler_battery(self, _: Any, data: bytearray) -> None:
+        """Handle battery notification."""
+        _LOGGER.debug("Battery received: %s", data.hex())
+        battery = int.from_bytes(data, byteorder="little")
+        if self.callback_battery:
+            self.callback_battery(battery)
+
+    def _handler(self, _: Any, data: bytearray) -> None:
+        """Handle notification data."""
+        _LOGGER.debug("Received: %s", data.hex())
+
+        if not data or len(data) < 1:
+            return
+
+        opcode = data[0]
+
+        try:
+            if opcode == RESPONSEIDS.FIRMWARE_VERSION:
+                self._parse_firmware_version(data)
+
+            elif opcode == RESPONSEIDS.CHALLENGE:
+                self._parse_challenge(data)
+
+            elif opcode == RESPONSEIDS.WAND_ADDRESS:
+                self._parse_box_address(data)
+
+            elif opcode == RESPONSEIDS.WAND_PRODUCT_INFORMATION:
+                self._parse_box_information(data)
+
+            elif opcode == RESPONSEIDS.LID_STATUS:
+                self._parse_lid_status(data)
+
+            elif opcode == RESPONSEIDS.LID_NOTIFY:
+                self._parse_lid_notify(data)
+
+            elif opcode == RESPONSEIDS.WAND_NOTIFY:
+                self._parse_wand_notify(data)
+
+            elif opcode == RESPONSEIDS.CHARGE_NOTIFY:
+                self._parse_charge_notify(data)
+
+            else:
+                _LOGGER.debug("Unknown opcode: 0x%02X, length=%d", opcode, len(data))
+
+        except Exception as e:
+            _LOGGER.error("Error in message handler for opcode 0x%02X: %s", opcode, e)
+            _LOGGER.debug("Stack trace:", exc_info=True)
+
+        # Signal waiting command if this message matches expected response
+        if self._waiting_for_msg_id is not None and opcode == self._waiting_for_msg_id:
+            _LOGGER.debug("Received expected response 0x%02X, signaling caller", opcode)
+            self._waiting_cmd_event.set()
+            self._waiting_for_msg_id = None
+
+    async def write_command(self, packet: bytes, timeout: float = 5.0) -> None:
+        """Write command and optionally wait for response."""
+        async with self.lock:
+            max_retries = 3
+
+            # Extract command ID from packet (first byte)
+            cmd_id = packet[0] if len(packet) > 0 else None
+            if cmd_id is None:
+                raise ValueError("Empty packet")
+
+            # Check if this command expects a response
+            expected_msg_id: int | None = MESSAGE_TO_RESPONSE_MAP.get(cmd_id)
+            expects_response: bool = expected_msg_id is not None
+
+            for attempt in range(1, max_retries + 1):
+                try:
+                    if expects_response:
+                        _LOGGER.debug("Sending command 0x%02X, expecting response 0x%02X", cmd_id, expected_msg_id)
+                        self._waiting_cmd_event.clear()
+                        self._waiting_for_msg_id = expected_msg_id
+                    else:
+                        _LOGGER.debug("Sending command 0x%02X (no response expected)", cmd_id)
+
+                    await self.write(COMMAND_UUID, packet, False)
+
+                    if expects_response:
+                        await wait_for(self._waiting_cmd_event.wait(), timeout)
+                        _LOGGER.debug("Command 0x%02X completed successfully", cmd_id)
+                    
+                    return
+                except Exception as err:
+                    if attempt < max_retries:
+                        _LOGGER.warning(
+                            "Write retry (attempt %d/%d): %s", attempt, max_retries, err
+                        )
+                        await sleep(0.5)
+                    else:
+                        raise
+
+    async def request_lid_status(self):
+        await self.write_command(struct.pack("B", MESSAGEIDS.LID_STATUS_SEND))
+
+    async def request_lid_notifications(self):
+        await self.write_command(struct.pack("B", MESSAGEIDS.LID_NOTIFY_REQUEST))
+
+    async def request_box_notifications(self):
+        await self.write_command(struct.pack("B", MESSAGEIDS.WAND_NOTIFY_REQUEST))
+
+    async def request_charge_notifications(self):
+        await self.write_command(struct.pack("B", MESSAGEIDS.CHARGE_NOTIFY_REQUEST))
+
+    async def get_box_address(self) -> str:
+        """Get box BLE address."""
+        if self._box_address is None:
+            await self.write_command(struct.pack("B", MESSAGEIDS.WAND_ADDRESS_READ))
+        return self._box_address or ""
+
+    async def get_box_device_id(self) -> str:
+        """Get box device ID."""
+        if self._box_device_id is None:
+            await self.write_command(struct.pack("BB", MESSAGEIDS.WAND_PRODUCT_INFORMATION_READ, 0x04))
+        return self._box_device_id or ""
+
+    async def get_box_firmware_version(self) -> str:
+        """Get box firmware version."""
+        if self._box_firmware_version is None:
+            await self.write_command(struct.pack("B", MESSAGEIDS.FIRMWARE_VERSION_READ))
+        return self._box_firmware_version or ""
+
+    async def get_box_serial_number(self) -> str:
+        """Get box serial number."""
+        if self._box_serial_number is None:
+            await self.write_command(struct.pack("BB", MESSAGEIDS.box_PRODUCT_INFORMATION_READ, 0x01))
+        return self._box_serial_number or ""
+    
+    async def get_box_sku(self) -> str:
+        """Get box SKU."""
+        if self._box_sku is None:
+            await self.write_command(struct.pack("BB", MESSAGEIDS.WAND_PRODUCT_INFORMATION_READ, 0x02))
+        return self._box_sku or ""
+
+    async def get_box_type(self) -> str:
+        """Get box type from the device ID."""
+        if self._box_type is None:
+            self._box_type = self._box_device_id_to_type(await self.get_box_device_id())
+        return self._box_type or ""
+
+    async def led_on(self, group: LedGroup, r: int, g: int, b: int) -> None:
+        """Set box LED color"""
+        _LOGGER.debug("Setting LED %s color to R=%d G=%d B=%d", group.name, r, g, b)
+
+        await self.write_command(struct.pack('BBBBB', MESSAGEIDS.LIGHT_CONTROL_SET_LED, int(group), r, g, b))
+
+    async def led_off(self) -> None:
+        """Turn off box LED"""
+        _LOGGER.debug("Turning off LED")
+        await self.write_command(struct.pack('B', MESSAGEIDS.LIGHT_CONTROL_CLEAR_ALL))
+
+    async def send_macro(self, macro: Macro) -> None:
+        """Send a macro sequence to the box."""
+        await self.write_command(macro.to_bytes())
+
+    async def buzz(self, duration_ms: int) -> None:
+        """Vibrate the box."""
+        macro = Macro().add_buzz(duration_ms)
+        await self.send_macro(macro)
+
+    def _parse_box_address(self, data: bytearray) -> None:
+        """Parse box address (ID 0x09)"""
+        if len(data) < 7:
+            return
+        try:
+            mac_le = data[1:7]
+            mac_be = mac_le[::-1]
+            self._box_address = ":".join(f"{b:02X}" for b in mac_be)
+            _LOGGER.debug("Box address: %s", self._box_address)
+        except Exception as e:
+            _LOGGER.error("Error parsing box address: %s", e)
+
+    def _parse_challenge(self, data: bytearray) -> None:
+        """Parse challenge response (ID 0x01)"""
+        if len(data) == 3:
+            self._box_challenge = struct.unpack('<H', data[1:3])[0]
+
+    def _parse_firmware_version(self, data: bytearray) -> None:
+        """Parse firmware version message (ID 0x00)
+
+        Response format: [0x00] [version_bytes...]
+        """
+        if len(data) < 2:
+            return
+        try:
+            # Skip first byte (opcode)
+            version_bytes = data[1:]
+
+            # Convert bytes to dotted version string (decimal values)
+            # e.g., [0, 3] -> "0.3", [1, 2, 3] -> "1.2.3"
+            version = ".".join(str(b) for b in version_bytes)
+
+            _LOGGER.debug("Firmware version: %s", version)
+            self._box_firmware_version = version
+        except Exception as e:
+            _LOGGER.error("Error parsing firmware version: %s", e)
+
+    def _parse_box_information(self, data: bytearray) -> None:
+        """Parse box information message (ID 0x0E)"""
+        if len(data) < 3:
+            return
+        try:
+            info_type = data[1]
+
+            if info_type == 0x01:
+                if len(data) >= 6:
+                    serial = struct.unpack('<I', data[2:6])[0]
+                    self._box_serial_number = str(serial)
+                    _LOGGER.debug("Box serial number: %s", self._box_serial_number)
+            elif info_type == 0x02:
+                self._box_sku = data[2:].decode('ascii', errors='ignore').strip('\x00')
+                _LOGGER.debug("Box SKU: %s", self._box_sku)
+            elif info_type == 0x04:
+                self._box_device_id = data[2:].decode('ascii', errors='ignore').strip('\x00')
+                _LOGGER.debug("Box device id: %s", self._box_device_id)
+        except Exception as e:
+            _LOGGER.error("Error parsing box information: %s", e)
+
+    def _box_device_id_to_type(self, device_id: str) -> str:
+        """Extract box type from device ID string
+
+        Device ID format: [prefix][type_suffix][variant_char]
+        Example: "WBMC22G1SHNW" -> "HN" -> "HONOURABLE"
+
+        Based on Android WandDeviceInfoFactory.kt
+
+        Args:
+            device_id: Device ID string from product info (e.g., "WBMC22G1SHNW")
+
+        Returns:
+            Wand type string (e.g., "HONOURABLE", "HEROIC", etc.)
+        """
+        if len(device_id) < 3:
+            return "UNKNOWN"
+
+        # Extract type suffix: drop last char, take last 2
+        # Example: "WBMC22G1SHNW" -> "WBMC22G1SHN" -> "HN"
+        type_suffix = device_id[:-1][-2:]
+
+        # Map suffix to wand type (from WandType.kt)
+        type_mapping = {
+            "DF": "DEFIANT",
+            "LY": "LOYAL",
+            "HR": "HEROIC",
+            "HN": "HONOURABLE",
+            "AV": "ADVENTUROUS",
+            "WS": "WISE",
+        }
+
+        return type_mapping.get(type_suffix, "UNKNOWN")
+
+    def _parse_lid_status(self, data: bytearray) -> None:
+        if len(data) < 2:
+            return
+
+        mapping = {
+            0x00: LIDSTATE.LID_ON_NO_WAND,
+            0x01: LIDSTATE.LID_OFF_NO_WAND,
+            0x02: LIDSTATE.LID_ON_WAND,
+            0x03: LIDSTATE.LID_OFF_WAND,
+        }
+
+        state = mapping.get(data[1], LIDSTATE.UNKNOWN)
+        _LOGGER.debug(f"Lid/Wand combined status: {state.name}")
+
+        if self.callback_lid_status:
+            self.callback_lid_status(state)
+
+    def _parse_lid_notify(self, data: bytearray) -> None:
+        if len(data) < 2:
+            return
+
+        state = LIDNOTIFY.LID_ON if data[1] == 0x00 else LIDNOTIFY.LID_REMOVED
+        _LOGGER.debug(f"Lid notify: {state.name}")
+
+        if self.callback_lid:
+            self.callback_lid(state)
+
+    def _parse_wand_notify(self, data: bytearray) -> None:
+        if len(data) < 2:
+            return
+
+        state = WANDNOTIFY.WAND_REMOVED if data[1] == 0x00 else WANDNOTIFY.WAND_PLUGGED
+        _LOGGER.debug(f"Wand notify: {state.name}")
+
+        if self.callback_wand:
+            self.callback_wand(state)
+
+    def _parse_charge_notify(self, data: bytearray) -> None:
+        if len(data) < 2:
+            return
+
+        state = CHARGENOTIFY.CHARGE_UNPLUGGED if data[1] == 0x00 else CHARGENOTIFY.CHARGE_PLUGGED
+        _LOGGER.debug(f"Charge notify: {state.name}")
+
+        if self.callback_charge:
+            self.callback_charge(state)
+

--- a/custom_components/magic_caster_wand/mcw_ble/mcw.py
+++ b/custom_components/magic_caster_wand/mcw_ble/mcw.py
@@ -47,6 +47,9 @@ class MESSAGEIDS:
     FACTORY_UNLOCK = 0xFE
     """FactoryUnlockMessage.kt"""
 
+    FRAME_START = 0x68
+    FRAME_CHANGE_LED = 0x22      # changeled: [group][r][g][b][duration_ms LE]
+
 # Response packet IDs from APK
 class RESPONSEIDS:
     FIRMWARE_VERSION = 0x00
@@ -461,11 +464,25 @@ class McwClient:
             self._wand_type = self._wand_device_id_to_type(await self.get_wand_device_id())
         return self._wand_type or ""
 
-    async def led_on(self, group: LedGroup, r: int, g: int, b: int) -> None:
+    async def led_on(self, group: LedGroup, r: int, g: int, b: int, duration_ms: int = 800) -> None:
         """Set wand LED color"""
-        _LOGGER.debug("Setting LED %s color to R=%d G=%d B=%d", group.name, r, g, b)
+        _LOGGER.debug("Setting LED %s color to R=%d G=%d B=%d for %d ms", group.name, r, g, b, duration_ms)
 
-        await self.write_command(struct.pack('BBBBB', MESSAGEIDS.LIGHT_CONTROL_SET_LED, int(group), r, g, b))
+        if duration_ms == 0:
+                duration_ms = 65535
+
+        await self.write_command(
+            struct.pack(
+                '<BBBBBBH',   # 1 byte start + 1 opcode + 4 bytes + uint16
+                MESSAGEIDS.FRAME_START,      # 0x68
+                MESSAGEIDS.FRAME_CHANGE_LED, # 0x22
+                int(group),                  # 0–3
+                r,
+                g,
+                b,
+                duration_ms                  # uint16 LE
+            )
+        )
 
     async def led_off(self) -> None:
         """Turn off wand LED"""

--- a/custom_components/magic_caster_wand/mcw_ble/mcw.py
+++ b/custom_components/magic_caster_wand/mcw_ble/mcw.py
@@ -470,33 +470,6 @@ class McwClient:
 
         await self.write_command(struct.pack('BBBBB', MESSAGEIDS.LIGHT_CONTROL_SET_LED, int(group), r, g, b))
 
-    async def set_led(self, group: LedGroup, r: int, g: int, b: int, duration_ms: int = 0) -> None:
-        """Set wand LED color"""
-        _LOGGER.debug("Setting LED %s color to R=%d G=%d B=%d for %d ms", group.name, r, g, b, duration_ms)
-
-        if duration_ms == 0:
-            payload = struct.pack(
-                '<BBBBBB',
-                MESSAGEIDS.FRAME_START,      
-                MESSAGEIDS.FRAME_CHANGE_LED,
-                int(group),
-                r,
-                g,
-                b
-            )
-        else:
-            payload = struct.pack(
-                '<BBBBBBH',
-                MESSAGEIDS.FRAME_START,
-                MESSAGEIDS.FRAME_CHANGE_LED,
-                int(group),
-                r,
-                g,
-                b,
-                duration_ms
-            
-        )
-
     async def led_off(self) -> None:
         """Turn off wand LED"""
         _LOGGER.debug("Turning off LED")

--- a/custom_components/magic_caster_wand/mcw_ble/mcw.py
+++ b/custom_components/magic_caster_wand/mcw_ble/mcw.py
@@ -464,24 +464,37 @@ class McwClient:
             self._wand_type = self._wand_device_id_to_type(await self.get_wand_device_id())
         return self._wand_type or ""
 
-    async def led_on(self, group: LedGroup, r: int, g: int, b: int, duration_ms: int = 800) -> None:
+    async def led_on(self, group: LedGroup, r: int, g: int, b: int) -> None:
+        """Set wand LED color"""
+        _LOGGER.debug("Setting LED %s color to R=%d G=%d B=%d", group.name, r, g, b)
+
+        await self.write_command(struct.pack('BBBBB', MESSAGEIDS.LIGHT_CONTROL_SET_LED, int(group), r, g, b))
+
+    async def set_led(self, group: LedGroup, r: int, g: int, b: int, duration_ms: int = 0) -> None:
         """Set wand LED color"""
         _LOGGER.debug("Setting LED %s color to R=%d G=%d B=%d for %d ms", group.name, r, g, b, duration_ms)
 
         if duration_ms == 0:
-                duration_ms = 65535
-
-        await self.write_command(
-            struct.pack(
-                '<BBBBBBH',   # 1 byte start + 1 opcode + 4 bytes + uint16
-                MESSAGEIDS.FRAME_START,      # 0x68
-                MESSAGEIDS.FRAME_CHANGE_LED, # 0x22
-                int(group),                  # 0–3
+            payload = struct.pack(
+                '<BBBBBB',
+                MESSAGEIDS.FRAME_START,      
+                MESSAGEIDS.FRAME_CHANGE_LED,
+                int(group),
+                r,
+                g,
+                b
+            )
+        else:
+            payload = struct.pack(
+                '<BBBBBBH',
+                MESSAGEIDS.FRAME_START,
+                MESSAGEIDS.FRAME_CHANGE_LED,
+                int(group),
                 r,
                 g,
                 b,
-                duration_ms                  # uint16 LE
-            )
+                duration_ms
+            
         )
 
     async def led_off(self) -> None:

--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -349,7 +349,12 @@ class McwDevice:
     async def set_led(self, group: LedGroup, r: int, g: int, b: int, duration: int = 0) -> None:
         """Set LED color."""
         if self.is_connected() and self._mcw:
-            await self._mcw.set_led(group, r, g, b, duration)
+            use_wait_clear = duration != 0
+            actual_duration = 65535 if not use_wait_clear else duration
+            macro = Macro().add_led(group, r, g, b, actual_duration)
+            if use_wait_clear:
+                macro.add_wait().add_clear()
+            await self._mcw.send_macro(macro)
 
     @property
     def casting_led_color(self) -> tuple[int, int, int]:

--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -459,7 +459,6 @@ class McbDevice:
         cn_lid,
         cn_charge,
         cn_wand,
-        cn_combined,
         cn_connection=None,
     ) -> None:
         """Register coordinators for all MCB notifications."""
@@ -467,18 +466,12 @@ class McbDevice:
         self._coordinator_lid = cn_lid
         self._coordinator_charge = cn_charge
         self._coordinator_wand = cn_wand
-        self._coordinator_combined = cn_combined
         self._coordinator_connection = cn_connection
 
     def _callback_battery(self, data: float) -> None:
         """Handle battery update callback."""
         if self._coordinator_battery:
             self._coordinator_battery.async_set_updated_data(data)
-
-    def _callback_lid_status(self, data: LIDSTATE) -> None:
-        """Handle lid status update callback."""
-        if self._coordinator_lid:
-            self._coordinator_lid.async_set_updated_data(data)
 
     def _callback_lid(self, data: LIDNOTIFY) -> None:
         """Handle lid notify callback."""
@@ -536,7 +529,6 @@ class McbDevice:
             self._mcb = McbClient(self.client)
             self._mcb.register_callback(
                 self._callback_battery,
-                self._callback_lid_status,
                 self._callback_lid,
                 self._callback_wand,
                 self._callback_charge,

--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -300,10 +300,56 @@ class McwDevice:
         if self.is_connected() and self._mcw:
             await self._mcw.send_macro(macro)
 
+    async def send_macro_parse(self, commands: list) -> None:
+        """Convert service commands into a Macro and send it."""
+        if not self.is_connected() or not self._mcw:
+            return
+
+        macro = Macro()
+
+        for cmd in commands:
+
+            if "changeled" in cmd:
+                c = cmd["changeled"]
+                group_val = c.get("group", "TIP")
+
+                # Accept both numeric and string groups
+                if isinstance(group_val, int):
+                    group = LedGroup(group_val)
+                else:
+                    group = LedGroup[group_val.upper()]
+
+                r, g, b = c.get("rgb", (255, 255, 255))
+                duration = int(c.get("duration", 800))
+                if duration == 0:
+                    duration = 65535
+
+                macro.add_led(group, r, g, b, duration)
+
+            elif "clear" in cmd:
+                macro.add_clear()
+
+            elif "delay" in cmd:
+                macro.add_delay(int(cmd["delay"]))
+
+            elif "buzz" in cmd:
+                macro.add_buzz(int(cmd["buzz"]))
+
+            elif "loop" in cmd:
+                macro.add_loop()
+
+            elif "set_loops" in cmd:
+                macro.add_set_loops(int(cmd["set_loops"]))
+
+            elif "wait" in cmd:
+                macro.add_wait()
+
+        await self._mcw.send_macro(macro)
+
     async def set_led(self, group: LedGroup, r: int, g: int, b: int, duration: int = 0) -> None:
         """Set LED color."""
         if self.is_connected() and self._mcw:
-            await self._mcw.set_led(group, r, g, b, duration)
+            await self._mcw.led_on(group, r, g, b, duration)
 
     @property
     def casting_led_color(self) -> tuple[int, int, int]:
@@ -336,7 +382,7 @@ class McwDevice:
     async def clear_leds(self) -> None:
         """Clear all LEDs."""
         if self.is_connected() and self._mcw:
-            await self._mcw.clear_leds()
+            await self._mcw.led_off()
 
     async def send_button_calibration(self) -> None:
         """Send button calibration packet."""

--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -11,6 +11,7 @@ from bluetooth_sensor_state_data import BluetoothData
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 from .mcw import McwClient, LedGroup, Macro
+from .mcb import McbClient, LIDSTATE, LIDNOTIFY, WANDNOTIFY, CHARGENOTIFY
 from .remote_tensor_spell_detector import RemoteTensorSpellDetector
 from .spell_tracker import SpellTracker
 
@@ -439,6 +440,213 @@ class McwDevice:
             await self._spell_tracker.close()
             # Do NOT set self._spell_tracker = None to keep upload state
 
+class McbDevice:
+    """Data handler for Magic Caster Box BLE device."""
+
+    def __init__(self, address: str) -> None:
+        """Initialize the device."""
+        self.address = address
+        self.client: BleakClient | None = None
+        self.model: str | None = None
+        self._mcb: McbClient | None = None
+        self._data = BLEData()
+        self._coordinator_battery = None
+        self._coordinator_connection = None
+
+    def register_coordinator(
+        self,
+        cn_battery,
+        cn_lid,
+        cn_charge,
+        cn_wand,
+        cn_combined,
+        cn_connection=None,
+    ) -> None:
+        """Register coordinators for all MCB notifications."""
+        self._coordinator_battery = cn_battery
+        self._coordinator_lid = cn_lid
+        self._coordinator_charge = cn_charge
+        self._coordinator_wand = cn_wand
+        self._coordinator_combined = cn_combined
+        self._coordinator_connection = cn_connection
+
+    def _callback_battery(self, data: float) -> None:
+        """Handle battery update callback."""
+        if self._coordinator_battery:
+            self._coordinator_battery.async_set_updated_data(data)
+
+    def _callback_lid_status(self, data: LIDSTATE) -> None:
+        """Handle lid status update callback."""
+        if self._coordinator_lid:
+            self._coordinator_lid.async_set_updated_data(data)
+
+    def _callback_lid(self, data: LIDNOTIFY) -> None:
+        """Handle lid notify callback."""
+        if self._coordinator_lid:
+            self._coordinator_lid.async_set_updated_data(data)
+
+    def _callback_wand(self, data: WANDNOTIFY) -> None:
+        """Handle wand-present callback."""
+        if self._coordinator_wand:
+            self._coordinator_wand.async_set_updated_data(data)
+
+    def _callback_charge(self, data: CHARGENOTIFY) -> None:
+        """Handle charging state callback."""
+        if self._coordinator_charge:
+            self._coordinator_charge.async_set_updated_data(data)
+
+    def _on_disconnect(self, client: BleakClient) -> None:
+        """Handle BLE device disconnection."""
+        _LOGGER.debug("Disconnected from Magic Caster Box")
+        self.client = None
+        self._mcb = None
+        if self._coordinator_connection:
+            self._coordinator_connection.async_set_updated_data(False)
+
+    def is_connected(self) -> bool:
+        """Check if the device is currently connected."""
+        if self.client:
+            try:
+                return self.client.is_connected
+            except Exception:
+                pass
+        return False
+
+    async def connect(self, ble_device: BLEDevice) -> bool:
+        """Connect to the BLE device."""
+        if self.is_connected():
+            return True
+
+        try:
+            self.client = await establish_connection(
+                BleakClient, ble_device, ble_device.address,
+                disconnected_callback=self._on_disconnect
+            )
+
+            if not self.client.is_connected:
+                return False
+
+            # Update basic device info
+            if not self._data.name:
+                self._data.name = ble_device.name or "Magic Caster Box"
+            if not self._data.address:
+                self._data.address = ble_device.address
+            if not self._data.identifier:
+                self._data.identifier = ble_device.address.replace(":", "")[-8:]
+            self._mcb = McbClient(self.client)
+            self._mcb.register_callback(
+                self._callback_battery,
+                self._callback_lid_status,
+                self._callback_lid,
+                self._callback_wand,
+                self._callback_charge,
+            )
+            await self._mcb.start_notify()
+            if not self.model:
+                self.model = await self._mcb.get_box_device_id()
+                
+            _LOGGER.debug("Connected to Magic Caster Box: %s, %s", ble_device.address, self.model)
+            if self._coordinator_connection:
+                self._coordinator_connection.async_set_updated_data(True)
+            return True
+
+        except Exception as err:
+            _LOGGER.warning("Failed to connect to %s: %s", ble_device.address, err)
+            return False
+
+    async def disconnect(self) -> None:
+        """Disconnect from the BLE device."""
+        if self.client:
+            try:
+                if self.client.is_connected:
+                    await self.client.disconnect()
+            except Exception as err:
+                _LOGGER.warning("Error during disconnect: %s", err)
+            finally:
+                if self._coordinator_connection:
+                    self._coordinator_connection.async_set_updated_data(False)
+
+    async def update_device(self, ble_device: BLEDevice) -> BLEData:
+        """Update device data. Sends keep-alive if connected."""
+        if ble_device and not self.model:
+            # Connect temporarily to fetch device info (model)
+            if await self.connect(ble_device):
+                await self.disconnect()
+        # Send keep-alive if connected
+        # if self.is_connected() and self._mcw:
+        #     try:
+        #         await self._mcw.keep_alive()
+        #     except Exception as err:
+        #         _LOGGER.debug("Keep-alive failed: %s", err)
+
+        # _LOGGER.debug("Updated BLEData: %s", self._data)
+        return self._data
+
+    async def send_macro(self, macro: Macro) -> None:
+        """Send a macro sequence to the wand."""
+        if self.is_connected() and self._mcb:
+            await self._mcb.send_macro(macro)
+
+    async def send_macro_parse(self, commands: list) -> None:
+        """Convert service commands into a Macro and send it."""
+        if not self.is_connected() or not self._mcb:
+            return
+
+        macro = Macro()
+
+        for cmd in commands:
+
+            if "changeled" in cmd:
+                c = cmd["changeled"]
+                group_val = c.get("group", "TIP")
+
+                # Accept both numeric and string groups
+                if isinstance(group_val, int):
+                    group = LedGroup(group_val)
+                else:
+                    group = LedGroup[group_val.upper()]
+
+                r, g, b = c.get("rgb", (255, 255, 255))
+                duration = int(c.get("duration", 800))
+                if duration == 0:
+                    duration = 65535
+
+                macro.add_led(group, r, g, b, duration)
+
+            elif "clear" in cmd:
+                macro.add_clear()
+
+            elif "delay" in cmd:
+                macro.add_delay(int(cmd["delay"]))
+
+            elif "buzz" in cmd:
+                macro.add_buzz(int(cmd["buzz"]))
+
+            elif "loop" in cmd:
+                macro.add_loop()
+
+            elif "set_loops" in cmd:
+                macro.add_set_loops(int(cmd["set_loops"]))
+
+            elif "wait" in cmd:
+                macro.add_wait()
+
+        await self._mcb.send_macro(macro)
+
+    async def set_led(self, group: LedGroup, r: int, g: int, b: int, duration: int = 0) -> None:
+        """Set LED color."""
+        if self.is_connected() and self._mcb:
+            use_wait_clear = duration != 0
+            actual_duration = 65535 if not use_wait_clear else duration
+            macro = Macro().add_led(group, r, g, b, actual_duration)
+            if use_wait_clear:
+                macro.add_wait().add_clear()
+            await self._mcb.send_macro(macro)
+
+    async def clear_leds(self) -> None:
+        """Clear all LEDs."""
+        if self.is_connected() and self._mcb:
+            await self._mcb.led_off()
 
 class McwBluetoothDeviceData(BluetoothData):
     """Bluetooth device data for Magic Caster Wand."""
@@ -447,6 +655,7 @@ class McwBluetoothDeviceData(BluetoothData):
     SERVICE_UUID = "57420001-587e-48a0-974c-544d6163c577"
     # Device name prefix
     DEVICE_NAME_PREFIX = "MCW-"
+    device_type = "mcw"
 
     def __init__(self) -> None:
         """Initialize the device data."""
@@ -461,6 +670,34 @@ class McwBluetoothDeviceData(BluetoothData):
             return False
 
         # Check for Magic Caster Wand Service UUID
+        # service_uuids_lower = [uuid.lower() for uuid in data.service_uuids]
+        # if self.SERVICE_UUID.lower() not in service_uuids_lower:
+        #     return False
+
+        return True
+
+class McbBluetoothDeviceData(BluetoothData):
+    """Bluetooth device data for Magic Caster Box."""
+
+    # Magic Caster Box Service UUID (from mcb.py)
+    SERVICE_UUID = "57420001-587e-48a0-974c-54686f72c577"
+    # Device name prefix
+    DEVICE_NAME_PREFIX = "MCB-"
+    device_type = "mcb"
+
+    def __init__(self) -> None:
+        """Initialize the device data."""
+        super().__init__()
+        self.last_service_info: BluetoothServiceInfoBleak | None = None
+        self.pending = True
+
+    def supported(self, data: BluetoothServiceInfoBleak) -> bool:
+        """Check if the device is a supported Magic Caster Box."""
+        # Check device name starts with "MCB-"
+        if not data.name or not data.name.startswith(self.DEVICE_NAME_PREFIX):
+            return False
+
+        # Check for Magic Caster Box Service UUID
         # service_uuids_lower = [uuid.lower() for uuid in data.service_uuids]
         # if self.SERVICE_UUID.lower() not in service_uuids_lower:
         #     return False

--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -349,7 +349,7 @@ class McwDevice:
     async def set_led(self, group: LedGroup, r: int, g: int, b: int, duration: int = 0) -> None:
         """Set LED color."""
         if self.is_connected() and self._mcw:
-            await self._mcw.led_on(group, r, g, b, duration)
+            await self._mcw.set_led(group, r, g, b, duration)
 
     @property
     def casting_led_color(self) -> tuple[int, int, int]:

--- a/custom_components/magic_caster_wand/select.py
+++ b/custom_components/magic_caster_wand/select.py
@@ -23,9 +23,11 @@ async def async_setup_entry(
     """Set up the Magic Caster Wand BLE select entity."""
     data = hass.data[DOMAIN][entry.entry_id]
     address = data["address"]
-    mcw: McwDevice = data["mcw"]
+    device = data["device"]
+    device_type = data["type"]
 
-    async_add_entities([McwCastingLedColorSelect(address, mcw)])
+    if device_type == "mcw":
+        async_add_entities([McwCastingLedColorSelect(address, device)])
 
 
 class McwCastingLedColorSelect(SelectEntity, RestoreEntity):

--- a/custom_components/magic_caster_wand/sensor.py
+++ b/custom_components/magic_caster_wand/sensor.py
@@ -1,5 +1,6 @@
 """Support for Magic Caster Wand BLE sensors."""
 
+from html import entities
 import logging
 
 from homeassistant.components.sensor import (
@@ -62,34 +63,37 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Magic Caster Wand BLE sensors."""
     data = hass.data[DOMAIN][entry.entry_id]
-    spell_coordinator: DataUpdateCoordinator[str] = data["spell_coordinator"]
     battery_coordinator: DataUpdateCoordinator[float] = data["battery_coordinator"]
-    calibration_coordinator: DataUpdateCoordinator[dict[str, str]] = data["calibration_coordinator"]
     connection_coordinator: DataUpdateCoordinator[bool] = data["connection_coordinator"]
     address = data["address"]
-    mcw = data["mcw"]
+    device = data["device"]
+    device_type = data["type"]
 
-    entities = [
-        McwSpellSensor(address, mcw, spell_coordinator, connection_coordinator),
-        McwBatterySensor(address, mcw, battery_coordinator, connection_coordinator),
-        McwBatteryStateSensor(address, mcw, battery_coordinator, connection_coordinator),
-        McwSpellModeSensor(address, mcw, connection_coordinator),
-    ]
-
-    # Add calibration sensors
-    for sensor in CALIBRATION_SENSORS:
-        entities.append(
-            McwCalibrationSensor(
-                address=address,
-                mcw=mcw,
-                coordinator=calibration_coordinator,
-                connection_coordinator=connection_coordinator,
-                sensor_key=sensor["key"],
-                sensor_name=sensor["name"],
-                sensor_icon=sensor["icon"],
+    entities = []
+    if device_type == "mcw":
+        spell_coordinator: DataUpdateCoordinator[str] = data["spell_coordinator"]
+        calibration_coordinator: DataUpdateCoordinator[dict[str, str]] = data["calibration_coordinator"]
+        entities.extend([
+            McwSpellSensor(address, device, spell_coordinator, connection_coordinator),
+            McwSpellModeSensor(address, device, connection_coordinator),
+        ])
+        # Add calibration sensors
+        for sensor in CALIBRATION_SENSORS:
+            entities.append(
+                McwCalibrationSensor(
+                    address=address,
+                    mcw=device,
+                    coordinator=calibration_coordinator,
+                    connection_coordinator=connection_coordinator,
+                    sensor_key=sensor["key"],
+                    sensor_name=sensor["name"],
+                    sensor_icon=sensor["icon"],
+                )
             )
-        )
-
+    entities.extend([
+        McwBatterySensor(address, device, battery_coordinator, connection_coordinator),
+        McwBatteryStateSensor(address, device, battery_coordinator, connection_coordinator),
+    ])
     async_add_entities(entities)
 
 

--- a/custom_components/magic_caster_wand/services.yaml
+++ b/custom_components/magic_caster_wand/services.yaml
@@ -64,18 +64,10 @@ send_macro:
     list is converted into a Macro and sent as a single CONTROL (0x68) macro
     packet. Commands execute in order and may include LED transitions, delays,
     vibration, loop markers, loop counts, and wait instructions.
-
+  target:
+    device:
+      integration: magic_caster_wand
   fields:
-
-    device_id:
-      name: Target Device
-      description: >
-        The Magic Caster Wand device to send the macro to.
-      required: true
-      selector:
-        device:
-          integration: magic_caster_wand
-
     commands:
       name: Macro Commands
       description: >

--- a/custom_components/magic_caster_wand/services.yaml
+++ b/custom_components/magic_caster_wand/services.yaml
@@ -94,13 +94,13 @@ send_macro:
           - Fields:
               buzz: Duration in ms
 
-        **loop**
-          - Marks the start of a loop block.
-
         **set_loops**
-          - Sets the number of loop iterations.
+          - Starts the loop for a number of loop iterations.
           - Fields:
               set_loops: Number of loops (1–255)
+
+        **loop**
+          - Marks the end of a loop block.
 
         **wait**
           - Waits for previous commands to finish.

--- a/custom_components/magic_caster_wand/services.yaml
+++ b/custom_components/magic_caster_wand/services.yaml
@@ -57,6 +57,66 @@ set_led:
           max: 30000
           unit_of_measurement: ms
 
+send_macro:
+  name: Send Wand Macro
+  description: >
+    Send a sequence of Magic Caster Wand macro commands. Each command in the
+    list is converted into a Macro and sent as a single CONTROL (0x68) macro
+    packet. Commands execute in order and may include LED transitions, delays,
+    vibration, loop markers, loop counts, and wait instructions.
+
+  fields:
+
+    device_id:
+      name: Target Device
+      description: >
+        The Magic Caster Wand device to send the macro to.
+      required: true
+      selector:
+        device:
+          integration: magic_caster_wand
+
+    commands:
+      name: Macro Commands
+      description: >
+        A list of macro commands executed in order. Each command is an object
+        with one of the following keys:
+
+        **changeled**
+          - Change LED color on a specific group.
+          - Fields:
+              group: TIP | MID_UPPER | MID_LOWER | POMMEL (or 0–3)
+              rgb: [R, G, B] (0–255 each)
+              duration: Duration in ms (max 65535)
+
+        **clear**
+          - Clears all LEDs immediately.
+
+        **delay**
+          - Adds a delay before the next command.
+          - Fields:
+              delay: Duration in ms
+
+        **buzz**
+          - Vibrates the wand.
+          - Fields:
+              buzz: Duration in ms
+
+        **loop**
+          - Marks the start of a loop block.
+
+        **set_loops**
+          - Sets the number of loop iterations.
+          - Fields:
+              set_loops: Number of loops (1–255)
+
+        **wait**
+          - Waits for previous commands to finish.
+
+      required: true
+      selector:
+        object:
+
 clear_leds:
   name: Clear LEDs
   description: Turn off all LEDs on the wand.

--- a/custom_components/magic_caster_wand/switch.py
+++ b/custom_components/magic_caster_wand/switch.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
 from .const import DOMAIN, MANUFACTURER, SIGNAL_SPELL_MODE_CHANGED
-from .mcw_ble import BLEData
+from .mcw_ble import McwDevice, McbDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,15 +26,16 @@ async def async_setup_entry(
     """Set up the Magic Caster Wand BLE switch."""
     data = hass.data[DOMAIN][entry.entry_id]
     address = data["address"]
-    mcw = data["mcw"]
+    device = data["device"]
+    device_type = data["type"]
     connection_coordinator = data["connection_coordinator"]
 
-    async_add_entities([
-        McwConnectionSwitch(hass, address, mcw, connection_coordinator),
-        McwSpellTrackingSwitch(hass, address, mcw, connection_coordinator)
-    ])
-
-
+    entities = []
+    entities.append(McwConnectionSwitch(hass, address, device, connection_coordinator))
+    if device_type == "mcw":
+        entities.append(McwSpellTrackingSwitch(hass, address, device, connection_coordinator))
+    async_add_entities(entities)
+    
 class McwConnectionSwitch(CoordinatorEntity, SwitchEntity):
     """Switch entity for controlling BLE connection."""
 
@@ -44,14 +45,14 @@ class McwConnectionSwitch(CoordinatorEntity, SwitchEntity):
         self, 
         hass: HomeAssistant, 
         address: str, 
-        mcw, 
+        device: McwDevice | McbDevice, 
         connection_coordinator: DataUpdateCoordinator[bool],
     ) -> None:
         """Initialize the connection switch."""
         super().__init__(connection_coordinator)
         self._hass = hass
         self._address = address
-        self._mcw = mcw
+        self._device = device
         self._identifier = address.replace(":", "")[-8:]
         self._attr_name = "Connect"
         self._attr_unique_id = f"mcw_{self._identifier}_connect"
@@ -60,14 +61,15 @@ class McwConnectionSwitch(CoordinatorEntity, SwitchEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         # Only available if we have received initial data and device model is known
-        return super().available and self._mcw is not None
+        return super().available and self._device is not None
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
+        device_label = "Wand" if isinstance(self._device, McwDevice) else "Box"
         return DeviceInfo(
             connections={(CONNECTION_BLUETOOTH, self._address)},
-            name=f"Magic Caster Wand {self._identifier}",
+            name=f"Magic Caster {device_label} {self._identifier}",
             manufacturer=MANUFACTURER,
         )
 
@@ -84,13 +86,13 @@ class McwConnectionSwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs) -> None:
         """Connect to the device."""
         ble_device = bluetooth.async_ble_device_from_address(self._hass, self._address)
-        if ble_device and self._mcw:
-            await self._mcw.connect(ble_device)
+        if ble_device and self._device:
+            await self._device.connect(ble_device)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Disconnect from the device."""
-        if self._mcw:
-            await self._mcw.disconnect()
+        if self._device:
+            await self._device.disconnect()
 
 
 class McwSpellTrackingSwitch(CoordinatorEntity, SwitchEntity):

--- a/custom_components/magic_caster_wand/text.py
+++ b/custom_components/magic_caster_wand/text.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceIn
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, MANUFACTURER
+from .mcw_ble import McbDevice, McwDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,8 +22,9 @@ async def async_setup_entry(
     """Set up the Magic Caster Wand BLE text entity."""
     data = hass.data[DOMAIN][entry.entry_id]
     address = data["address"]
+    device = data["device"]
 
-    async_add_entities([McwAliasTextEntity(address)])
+    async_add_entities([McwAliasTextEntity(address, device)])
 
 
 class McwAliasTextEntity(RestoreText):
@@ -30,10 +32,11 @@ class McwAliasTextEntity(RestoreText):
 
     _attr_has_entity_name = True
 
-    def __init__(self, address: str) -> None:
+    def __init__(self, address: str, device: McwDevice | McbDevice) -> None:
         """Initialize the text entity."""
         self._address = address
         self._identifier = address.replace(":", "")[-8:]
+        self._device = device
         self._attr_name = "Alias"
         self._attr_unique_id = f"mcw_{self._identifier}_alias"
         self._attr_native_max = 32
@@ -44,9 +47,10 @@ class McwAliasTextEntity(RestoreText):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device info."""
+        device_label = "Wand" if isinstance(self._device, McwDevice) else "Box"
         return DeviceInfo(
             connections={(CONNECTION_BLUETOOTH, self._address)},
-            name=f"Magic Caster Wand {self._identifier}",
+            name=f"Magic Caster {device_label} {self._identifier}",
             manufacturer=MANUFACTURER,
         )
 


### PR DESCRIPTION
This fixes the service calls for clear LED and set LED and adds a send Macro service for more complex lighting patterns.

It adds Magic Caster Box functionality. The clear and set LED and send Macro services all work with the Box but there is only one group of LEDs and no vibration available. It also has the same battery sensor as the Wand. 

It otherwise exposes 3 sensors for the Box:

1. Whether the lid is on or off;
2. Whether the wand is connected to the box;
3. Whether a USB is plugged in.

This allows automations so that when the wand is removed from the box it is connected and when the wand is put back into the box for it to be disconnected.

I am not sure but it seems that connecting to the Box may require connecting to the linked Wand first as it frequently wouldn't connect. But once connected it seems to be fairly stable.