### PR TITLE
Fix spell tracking not resuming after a wand reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ pythonenv*
 venv
 .venv
 .pytest_cache
+
+# Local backups of the bundled model. These are hundreds of KB of binary and
+# have no business in the history.
+*.bak

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ venv
 # Local backups of the bundled model. These are hundreds of KB of binary and
 # have no business in the history.
 *.bak
+
+# The model itself, for the same reason. It is served by the TFLite add-on
+# rather than shipped with the integration -- model_name is only what the
+# client asks the server for, so nothing here needs to track one.
+*.tflite

--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -146,6 +146,7 @@ class McwDevice:
         self._spell_timeout = spell_timeout
         self._spell_tracker: SpellTracker | None = None
         self._button_all_pressed: bool = False
+        self._imu_streaming: bool = False
         self._spell_reset_timeout_task: asyncio.Task[None] | None = None
         self._background_tasks: set[asyncio.Task] = set()
         self._casting_led_color: tuple[int, int, int] = (0, 0, 255)  # Default color: blue
@@ -230,12 +231,10 @@ class McwDevice:
         if self._coordinator_buttons:
             self._coordinator_buttons.async_set_updated_data(data)
 
-        # Handle spell tracking start/stop when using server-side detection
-        if (
-            self._spell_tracker is not None
-            and self._spell_tracker.detector is not None
-            and self._spell_tracker.detector.is_active
-        ):
+        # Handle spell tracking start/stop when using server-side detection.
+        # Gated on streaming being armed too: without IMU samples a cast can only
+        # ever fail recognition, so lighting the casting LED would promise nothing.
+        if self.spell_tracking_active:
             button_all = data.get("button_all", False)
 
             # Transition: not pressed -> pressed = start tracking
@@ -293,11 +292,7 @@ class McwDevice:
         if self._coordinator_imu:
             self._coordinator_imu.async_set_updated_data(data)
 
-        if (
-            self._spell_tracker is not None
-            and self._spell_tracker.detector is not None
-            and self._spell_tracker.detector.is_active
-        ):
+        if self.spell_tracking_active:
             for sample in data:
                 self._spell_tracker.update(
                     ax=sample["accel_y"],
@@ -308,11 +303,25 @@ class McwDevice:
                     gz=sample["gyro_z"],
                 )
 
+    def _reset_cast_state(self) -> None:
+        """Drop any in-flight cast so it cannot bleed across a reconnect.
+
+        Disconnecting mid-cast leaves the recording open and button_all latched
+        true. The wand reports buttons as released while disconnected, so without
+        this the next press is not seen as a transition (no cast starts), and the
+        samples from the interrupted cast would be prepended to the following one.
+        """
+        self._imu_streaming = False
+        self._button_all_pressed = False
+        if self._spell_tracker is not None:
+            self._spell_tracker.abort()
+
     def _on_disconnect(self, client: BleakClient) -> None:
         """Handle BLE device disconnection."""
         _LOGGER.debug("Disconnected from Magic Caster Wand")
         self.client = None
         self._mcw = None
+        self._reset_cast_state()
         if self._coordinator_connection:
             self._coordinator_connection.async_set_updated_data(False)
 
@@ -386,14 +395,25 @@ class McwDevice:
         the callbacks still fire and light the casting LED, but no IMU samples ever
         arrive, so every cast is recognized from a single position and silently
         discarded until the Spell Tracking switch is toggled off and on again.
+
+        A failure here must not be swallowed: reporting the wand as tracking while
+        it is not is the very state this method exists to prevent, so _imu_streaming
+        stays False and the Spell Tracking switch shows off, which is both truthful
+        and the thing the user can act on.
         """
-        if not self.spell_tracking_active or not self._mcw:
+        if not self.spell_tracking_wanted or not self._mcw:
             return
         try:
             await self._mcw.imu_streaming_start()
+            self._imu_streaming = True
             _LOGGER.debug("Resumed IMU streaming after connect")
         except Exception as err:
-            _LOGGER.warning("Failed to resume IMU streaming after connect: %s", err)
+            self._imu_streaming = False
+            _LOGGER.warning(
+                "Failed to resume IMU streaming after connect: %s. "
+                "Spell tracking is off until the Spell Tracking switch is toggled",
+                err,
+            )
 
     async def _cancel_background_tasks(self) -> None:
         """Cancel anything still running so it cannot outlive the config entry."""
@@ -411,6 +431,9 @@ class McwDevice:
     async def disconnect(self) -> None:
         """Disconnect from the BLE device."""
         await self._cancel_background_tasks()
+        # Before the client check: an explicit disconnect must clear the cast even
+        # if the link is already gone, and _on_disconnect does not always fire.
+        self._reset_cast_state()
 
         if self.client:
             try:
@@ -489,17 +512,32 @@ class McwDevice:
 
     @property
     def spell_detection_mode(self) -> str:
-        """Get the current spell detection mode."""
-        return "Server" if self.spell_tracking_active else "Wand"
+        """Get the current spell detection mode.
+
+        Follows intent rather than streaming state: which detector is configured
+        does not change just because a reconnect has yet to re-arm the stream.
+        """
+        return "Server" if self.spell_tracking_wanted else "Wand"
+
+    @property
+    def spell_tracking_wanted(self) -> bool:
+        """Whether spell tracking is meant to be running.
+
+        The detector session is owned by this object and survives a disconnect,
+        so this is the user's intent: it stays true across a reconnect and is what
+        decides whether streaming should be re-armed.
+        """
+        return self._spell_tracker is not None and self._spell_tracker.is_active
 
     @property
     def spell_tracking_active(self) -> bool:
-        """Whether spell tracking is running.
+        """Whether spell tracking is actually running.
 
-        This is the same flag the button and IMU callbacks gate on, so anything
-        reading it cannot drift out of sync with what those callbacks will do.
+        Intent alone is not enough -- IMU streaming is firmware state that a
+        reconnect clears and a failed resume never restores. Requiring both means
+        this cannot claim tracking while no samples are arriving.
         """
-        return self._spell_tracker is not None and self._spell_tracker.is_active
+        return self.spell_tracking_wanted and self._imu_streaming
 
     @property
     def server_reachable(self) -> bool:
@@ -530,9 +568,11 @@ class McwDevice:
         """Start IMU streaming."""
         if self.is_connected() and self._mcw:
             await self._mcw.imu_streaming_start()
+            self._imu_streaming = True
 
     async def imu_streaming_stop(self) -> None:
         """Stop IMU streaming."""
+        self._imu_streaming = False
         if self.is_connected() and self._mcw:
             await self._mcw.imu_streaming_stop()
 

--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -355,6 +355,7 @@ class McwDevice:
             )
             await self._mcw.start_notify()
             await self._refresh_model()
+            await self._resume_imu_streaming()
 
             _LOGGER.debug("Connected to Magic Caster Wand: %s, %s", ble_device.address, self.model)
             if self._coordinator_connection:
@@ -375,6 +376,24 @@ class McwDevice:
             return
         await self._mcw.init_wand()
         self.model = await self._mcw.get_wand_device_id()
+
+    async def _resume_imu_streaming(self) -> None:
+        """Re-arm IMU streaming if spell tracking is meant to be running.
+
+        IMU streaming is firmware state that dies with the connection, while the
+        detector session that gates the button and IMU callbacks is owned by this
+        object and outlives it. Without this, a reconnect leaves the two disagreeing:
+        the callbacks still fire and light the casting LED, but no IMU samples ever
+        arrive, so every cast is recognized from a single position and silently
+        discarded until the Spell Tracking switch is toggled off and on again.
+        """
+        if not self.spell_tracking_active or not self._mcw:
+            return
+        try:
+            await self._mcw.imu_streaming_start()
+            _LOGGER.debug("Resumed IMU streaming after connect")
+        except Exception as err:
+            _LOGGER.warning("Failed to resume IMU streaming after connect: %s", err)
 
     async def _cancel_background_tasks(self) -> None:
         """Cancel anything still running so it cannot outlive the config entry."""
@@ -471,10 +490,16 @@ class McwDevice:
     @property
     def spell_detection_mode(self) -> str:
         """Get the current spell detection mode."""
-        if self._spell_tracker is not None:
-            if self._spell_tracker.is_active:
-                return "Server"
-        return "Wand"
+        return "Server" if self.spell_tracking_active else "Wand"
+
+    @property
+    def spell_tracking_active(self) -> bool:
+        """Whether spell tracking is running.
+
+        This is the same flag the button and IMU callbacks gate on, so anything
+        reading it cannot drift out of sync with what those callbacks will do.
+        """
+        return self._spell_tracker is not None and self._spell_tracker.is_active
 
     @property
     def server_reachable(self) -> bool:

--- a/custom_components/magic_caster_wand/mcw_ble/spell_tracker.py
+++ b/custom_components/magic_caster_wand/mcw_ble/spell_tracker.py
@@ -167,6 +167,15 @@ class SpellTracker:
         )
         return None
 
+    def abort(self) -> None:
+        """Discard an in-flight recording without attempting recognition.
+
+        Used when a cast is interrupted rather than completed -- a disconnect
+        mid-gesture -- so the partial sample run cannot be carried into the next one.
+        """
+        self._state.tracking_active = 0
+        self._state.position_count = 0
+
     async def close(self) -> None:
         """Close the underlying detector."""
         if hasattr(self._detector, "close"):

--- a/custom_components/magic_caster_wand/mcw_ble/spell_tracker.py
+++ b/custom_components/magic_caster_wand/mcw_ble/spell_tracker.py
@@ -149,10 +149,23 @@ class SpellTracker:
         self._state.position_count = 1
         self._state.tracking_active = 1
 
+    _RECOGNITION_ERRORS = {
+        -1: "no movement detected",
+        -2: "not enough data points",
+        -3: "no spell recognized with sufficient confidence",
+        -4: "no detector configured",
+    }
+
     async def stop(self) -> str | None:
         self._state.tracking_active = 0
         result = await self._recognize_spell()
-        return result if isinstance(result, str) else None
+        if isinstance(result, str):
+            return result
+        _LOGGER.debug(
+            "Spell recognition failed: %s",
+            self._RECOGNITION_ERRORS.get(result, f"unknown error {result}"),
+        )
+        return None
 
     async def close(self) -> None:
         """Close the underlying detector."""

--- a/custom_components/magic_caster_wand/switch.py
+++ b/custom_components/magic_caster_wand/switch.py
@@ -132,11 +132,11 @@ class McwSpellTrackingSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return true if IMU streaming is active.
+        """Return true if spell tracking is actually running.
 
         Read from the device rather than tracked here, so the switch cannot report
-        "on" while the wand is idle -- the state the reconnect path restores is the
-        same one shown in the UI.
+        "on" while no IMU samples are arriving -- if a reconnect fails to re-arm
+        streaming, this goes off and tells the user there is something to fix.
         """
         if self.coordinator.data is not True or not self._mcw:
             return False
@@ -151,7 +151,11 @@ class McwSpellTrackingSwitch(CoordinatorEntity, SwitchEntity):
         """Start IMU streaming."""
         if self._mcw and self.coordinator.data is True:
             await self._mcw.async_spell_tracker_init()
-            await self._mcw.imu_streaming_start()
+            try:
+                await self._mcw.imu_streaming_start()
+            except Exception as err:
+                # is_on reads the device, so it already reports off; say why.
+                _LOGGER.error("Failed to start spell tracking: %s", err)
             async_dispatcher_send(self._hass, SIGNAL_SPELL_MODE_CHANGED)
             self.async_write_ha_state()
         elif self.coordinator.data is not True:

--- a/custom_components/magic_caster_wand/switch.py
+++ b/custom_components/magic_caster_wand/switch.py
@@ -115,7 +115,6 @@ class McwSpellTrackingSwitch(CoordinatorEntity, SwitchEntity):
         self._identifier = address.replace(":", "")[-8:]
         self._attr_name = "Spell Tracking"
         self._attr_unique_id = f"mcw_{self._identifier}_spell_tracking"
-        self._is_on = False
 
     @property
     def available(self) -> bool:
@@ -133,10 +132,15 @@ class McwSpellTrackingSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return true if IMU streaming is active."""
-        if self.coordinator.data is not True:
+        """Return true if IMU streaming is active.
+
+        Read from the device rather than tracked here, so the switch cannot report
+        "on" while the wand is idle -- the state the reconnect path restores is the
+        same one shown in the UI.
+        """
+        if self.coordinator.data is not True or not self._mcw:
             return False
-        return self._is_on
+        return self._mcw.spell_tracking_active
 
     @property
     def icon(self) -> str:
@@ -148,7 +152,6 @@ class McwSpellTrackingSwitch(CoordinatorEntity, SwitchEntity):
         if self._mcw and self.coordinator.data is True:
             await self._mcw.async_spell_tracker_init()
             await self._mcw.imu_streaming_start()
-            self._is_on = True
             async_dispatcher_send(self._hass, SIGNAL_SPELL_MODE_CHANGED)
             self.async_write_ha_state()
         elif self.coordinator.data is not True:
@@ -159,7 +162,9 @@ class McwSpellTrackingSwitch(CoordinatorEntity, SwitchEntity):
         if self._mcw:
             if self.coordinator.data is True:
                 await self._mcw.imu_streaming_stop()
-                await self._mcw.async_spell_tracker_close()
-            self._is_on = False
+            # Closing the tracker session is what clears the tracking state, so it
+            # must happen even while disconnected -- otherwise the switch would stay
+            # on and the next connect would re-arm streaming the user just stopped.
+            await self._mcw.async_spell_tracker_close()
             async_dispatcher_send(self._hass, SIGNAL_SPELL_MODE_CHANGED)
             self.async_write_ha_state()

--- a/tests/test_spell_tracking_reconnect.py
+++ b/tests/test_spell_tracking_reconnect.py
@@ -1,0 +1,347 @@
+"""Spell tracking across a reconnect.
+
+IMU streaming is firmware state that dies with the connection, while the detector
+session that gates the button and IMU callbacks outlives it. These tests pin the
+two together: a reconnect must re-arm streaming when tracking was on, must not
+when it was off, and must not claim to be tracking when re-arming failed.
+"""
+
+import asyncio
+
+import pytest
+
+from custom_components.magic_caster_wand.mcw_ble import parser
+from custom_components.magic_caster_wand.mcw_ble.parser import McwDevice
+
+
+class FakeClient:
+    """Minimal stand-in for the connected BleakClient."""
+
+    is_connected = True
+
+
+class FakeBleDevice:
+    """Minimal stand-in for the BLEDevice handed to connect()."""
+
+    name = "MCW-7E2939D2"
+    address = "AA:BB:CC:DD:EE:FF"
+
+
+class FakeSession:
+    """Stand-in for the detector's aiohttp session.
+
+    ``is_active`` is ``session is not None and not session.closed``, so an open
+    session is what represents "the user switched spell tracking on".
+    """
+
+    closed = False
+
+
+class FakeMcwClient:
+    """Records the streaming commands the device sends to the wand."""
+
+    def __init__(self, start_error: Exception | None = None) -> None:
+        self.calls: list[str] = []
+        self._start_error = start_error
+
+    async def imu_streaming_start(self) -> None:
+        self.calls.append("start")
+        if self._start_error is not None:
+            raise self._start_error
+
+    async def imu_streaming_stop(self) -> None:
+        self.calls.append("stop")
+
+    # -- used only when driving the real connect() --
+
+    def register_callback(self, *callbacks) -> None:
+        pass
+
+    async def start_notify(self) -> None:
+        self.calls.append("start_notify")
+
+    async def stop_notify(self) -> None:
+        self.calls.append("stop_notify")
+
+
+def make_device(tracking_wanted: bool, start_error: Exception | None = None) -> McwDevice:
+    """A connected wand whose tracker session reflects the user's intent.
+
+    ``is_active`` on the detector is what survives a disconnect, so setting it is
+    how a test says "the user had spell tracking switched on".
+    """
+    device = McwDevice("AA:BB:CC:DD:EE:FF")
+    device.client = FakeClient()
+    device._mcw = FakeMcwClient(start_error)
+    device._spell_tracker._detector._session = FakeSession() if tracking_wanted else None
+    return device
+
+
+def press_all_buttons(device: McwDevice, pressed: bool = True) -> None:
+    """Deliver a button notification inside a running loop.
+
+    The callback spawns the casting-LED write as a task, which needs a loop even
+    though the write itself goes to the fake client.
+    """
+
+    async def scenario():
+        device._callback_buttons({"button_all": pressed})
+        await asyncio.sleep(0)  # let the spawned LED task run
+
+    asyncio.run(scenario())
+
+
+def feed_imu(device: McwDevice, count: int) -> None:
+    """Deliver ``count`` identical IMU samples."""
+    sample = {"accel_x": 0.1, "accel_y": 0.2, "accel_z": 0.9, "gyro_x": 0.0, "gyro_y": 0.0, "gyro_z": 0.0}
+    device._callback_imu([sample] * count)
+
+
+def test_tracking_intent_reflects_the_detector_session():
+    """The fixture only means something if intent is wired to the session."""
+    assert make_device(tracking_wanted=True).spell_tracking_wanted is True
+    assert make_device(tracking_wanted=False).spell_tracking_wanted is False
+
+
+# ── Resuming on reconnect ────────────────────────────────────────────────────
+
+
+def test_reconnect_resumes_streaming_when_tracking_was_on():
+    device = make_device(tracking_wanted=True)
+
+    asyncio.run(device._resume_imu_streaming())
+
+    assert device._mcw.calls == ["start"], "streaming must be re-armed after a reconnect"
+    assert device.spell_tracking_active is True
+
+
+def test_each_resume_issues_a_single_start():
+    """One start per call, never a burst.
+
+    Re-arming is driven by connect(), which returns early for an already-open
+    connection, so the helper is reached once per actual reconnect. What it must
+    guarantee is that a call does not issue the command more than once.
+    """
+    device = make_device(tracking_wanted=True)
+
+    asyncio.run(device._resume_imu_streaming())
+    assert device._mcw.calls == ["start"]
+
+    asyncio.run(device._resume_imu_streaming())
+    assert device._mcw.calls == ["start", "start"], "a second reconnect re-arms once more"
+
+
+def test_reconnect_does_not_resume_when_tracking_was_off():
+    device = make_device(tracking_wanted=False)
+
+    asyncio.run(device._resume_imu_streaming())
+
+    assert device._mcw.calls == [], "streaming must stay off if the user never turned it on"
+    assert device.spell_tracking_active is False
+
+
+def connect_device(device: McwDevice, monkeypatch, start_error: Exception | None = None) -> bool:
+    """Drive the real connect() with the BLE layer stubbed out.
+
+    Patches the two things connect() reaches for -- the transport and the protocol
+    client -- so the rest of the method, including the resume step, runs as written.
+    """
+    fake_client = FakeMcwClient(start_error)
+
+    async def fake_establish(cls, ble_device, address, disconnected_callback=None):
+        return FakeClient()
+
+    monkeypatch.setattr(parser, "establish_connection", fake_establish)
+    monkeypatch.setattr(parser, "McwClient", lambda client: fake_client)
+    # The model probe talks to the wand; it is not what these tests are about.
+    device.model = "WBMC22G1SHNW"
+
+    return asyncio.run(device.connect(FakeBleDevice()))
+
+
+def test_connect_resumes_streaming_when_tracking_was_on(monkeypatch):
+    """The end-to-end wiring: reconnecting a wand that was tracking re-arms the
+    stream without the user touching the Spell Tracking switch."""
+    device = McwDevice("AA:BB:CC:DD:EE:FF")
+    device._spell_tracker._detector._session = FakeSession()
+
+    assert connect_device(device, monkeypatch) is True
+
+    assert device._mcw.calls == ["start_notify", "start"], "connect() must re-arm IMU streaming"
+    assert device.spell_tracking_active is True
+
+
+def test_connect_does_not_resume_when_tracking_was_off(monkeypatch):
+    device = McwDevice("AA:BB:CC:DD:EE:FF")
+
+    assert connect_device(device, monkeypatch) is True
+
+    assert device._mcw.calls == ["start_notify"], "a wand that was not tracking must stay idle"
+    assert device.spell_tracking_active is False
+
+
+def test_connect_succeeds_even_if_the_resume_fails(monkeypatch):
+    """A wand that is connected but not streaming still beats no wand at all, so
+    the failure must not take the connection down with it."""
+    device = McwDevice("AA:BB:CC:DD:EE:FF")
+    device._spell_tracker._detector._session = FakeSession()
+
+    assert connect_device(device, monkeypatch, start_error=RuntimeError("write failed")) is True
+
+    assert device.spell_tracking_wanted is True
+    assert device.spell_tracking_active is False, "a failed resume must not report as tracking"
+
+
+# ── A failed resume must not look like success ───────────────────────────────
+
+
+def test_failed_resume_is_not_reported_as_tracking():
+    """Logging and carrying on would recreate the bug: the switch would read on
+    while no IMU samples arrive."""
+    device = make_device(tracking_wanted=True, start_error=RuntimeError("write failed"))
+
+    asyncio.run(device._resume_imu_streaming())
+
+    assert device._mcw.calls == ["start"], "the attempt is still made"
+    assert device.spell_tracking_wanted is True, "the user's intent is unchanged"
+    assert device.spell_tracking_active is False, "but tracking must not claim to be running"
+
+
+def test_failed_resume_does_not_break_the_connection():
+    """A wand that is connected but not streaming still beats no wand at all."""
+    device = make_device(tracking_wanted=True, start_error=RuntimeError("write failed"))
+
+    asyncio.run(device._resume_imu_streaming())  # must not raise
+
+
+def test_failed_resume_is_logged(caplog):
+    device = make_device(tracking_wanted=True, start_error=RuntimeError("write failed"))
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(device._resume_imu_streaming())
+
+    assert "Failed to resume IMU streaming" in caplog.text
+
+
+def test_callbacks_stay_inert_while_streaming_is_down():
+    """With no samples arriving a cast can only fail, so it must not start."""
+    device = make_device(tracking_wanted=True, start_error=RuntimeError("write failed"))
+    asyncio.run(device._resume_imu_streaming())
+
+    press_all_buttons(device)
+
+    assert device._button_all_pressed is False, "no cast may start without IMU data"
+
+
+# ── Interrupted casts do not survive a reconnect ─────────────────────────────
+
+
+def test_disconnect_clears_an_interrupted_cast():
+    """Mid-cast the recording is open and button_all is latched. The wand reports
+    buttons released while disconnected, so a stale latch means the next press is
+    not seen as a transition and no cast ever starts."""
+    device = make_device(tracking_wanted=True)
+    asyncio.run(device._resume_imu_streaming())
+
+    press_all_buttons(device)
+    assert device._button_all_pressed is True
+    assert device._spell_tracker._state.tracking_active == 1
+
+    device._on_disconnect(device.client)
+
+    assert device._button_all_pressed is False, "a latched press must not survive a reconnect"
+    assert device._spell_tracker._state.tracking_active == 0, "the recording must be closed"
+    assert device._imu_streaming is False, "streaming is gone with the connection"
+
+
+def test_explicit_disconnect_clears_an_interrupted_cast():
+    device = make_device(tracking_wanted=True)
+    asyncio.run(device._resume_imu_streaming())
+    press_all_buttons(device)
+
+    asyncio.run(device.disconnect())
+
+    assert device._button_all_pressed is False
+    assert device._spell_tracker._state.tracking_active == 0
+
+
+def test_disconnect_clears_the_cast_even_without_a_client():
+    """disconnect() skips its body when the link is already gone, but the cast
+    state still has to be dropped."""
+    device = make_device(tracking_wanted=True)
+    asyncio.run(device._resume_imu_streaming())
+    press_all_buttons(device)
+    device.client = None
+
+    asyncio.run(device.disconnect())
+
+    assert device._button_all_pressed is False
+    assert device._imu_streaming is False
+
+
+def test_samples_do_not_bleed_into_the_next_cast():
+    """The positions recorded before a disconnect must not be prepended to the
+    cast that follows it."""
+    device = make_device(tracking_wanted=True)
+    asyncio.run(device._resume_imu_streaming())
+    press_all_buttons(device)
+
+    feed_imu(device, 5)
+    assert device._spell_tracker._state.position_count > 1
+
+    device._on_disconnect(device.client)
+
+    assert device._spell_tracker._state.position_count == 0, "the interrupted run must be discarded"
+
+
+def test_a_cast_works_normally_after_reconnecting():
+    """The whole point: press-release must be seen as a transition again without
+    the user touching the Spell Tracking switch."""
+    device = make_device(tracking_wanted=True)
+    asyncio.run(device._resume_imu_streaming())
+    press_all_buttons(device)
+    device._on_disconnect(device.client)
+
+    # Reconnect: a fresh client, and the resume step connect() performs.
+    device.client = FakeClient()
+    device._mcw = FakeMcwClient()
+    asyncio.run(device._resume_imu_streaming())
+
+    assert device.spell_tracking_active is True
+
+    press_all_buttons(device)
+
+    assert device._button_all_pressed is True, "the press must register as a new cast"
+    assert device._spell_tracker._state.tracking_active == 1
+
+
+# ── Streaming state tracks the explicit start/stop calls ─────────────────────
+
+
+def test_streaming_state_follows_start_and_stop():
+    device = make_device(tracking_wanted=True)
+
+    asyncio.run(device.imu_streaming_start())
+    assert device.spell_tracking_active is True
+
+    asyncio.run(device.imu_streaming_stop())
+    assert device.spell_tracking_active is False
+    assert device.spell_tracking_wanted is True, "stopping the stream is not withdrawing intent"
+
+
+def test_stopping_streaming_while_disconnected_still_clears_the_flag():
+    device = make_device(tracking_wanted=True)
+    asyncio.run(device._resume_imu_streaming())
+    device.client = None
+
+    asyncio.run(device.imu_streaming_stop())
+
+    assert device.spell_tracking_active is False
+
+
+@pytest.mark.parametrize("wanted", [True, False])
+def test_detection_mode_reports_server_only_when_intended(wanted):
+    """The mode sensor follows intent, not the momentary streaming state."""
+    device = make_device(tracking_wanted=wanted)
+
+    assert device.spell_detection_mode == ("Server" if wanted else "Wand")


### PR DESCRIPTION
## Problem

After a wand reconnects, spell tracking appears to work but silently does
nothing. Casts are recognised from a single position and discarded. The only
way to recover is toggling the Spell Tracking switch off and on.

Two pieces of state have to agree for tracking to work, and a reconnect
resets one but not the other:

- **IMU streaming** is firmware state, set by writing `IMUFLAG_SET` over BLE.
  It dies with the connection.
- **The detector session** is owned by `McwDevice` and deliberately outlives
  connections, and is what the button and IMU callbacks gate on.

Only `McwSpellTrackingSwitch.async_turn_on` set both. Nothing on the reconnect
path re-armed streaming, so after reconnecting the session was still open, the
callbacks still fired and lit the casting LED — but no IMU samples ever arrived.

From a user's debug log, the giveaway is recognition running with one position,
the seed point written by `SpellTracker.start()`, with no IMU traffic anywhere:

```
14:09:27.566 parser] All buttons pressed, starting spell tracking
14:09:28.903 spell_tracker] Spell recognition started with 1 positions
```

That is `_recognize_spell` returning `-2` ("not enough data points"), which
`stop()` collapsed to `None` — indistinguishable in the logs from no cast.

## Changes

**Re-arm streaming on connect.** `connect()` now calls `_resume_imu_streaming()`,
which re-issues `imu_streaming_start()` when tracking was on.

**Split tracking state in two,** because a resume can fail:

- `spell_tracking_wanted` — the user's intent (the detector session), survives
  a disconnect and decides whether to re-arm.
- `spell_tracking_active` — additionally requires streaming to be armed.

The switch and the callbacks read `active`, so a failed resume reports off
rather than recreating the same misleading state the fix exists to prevent. The
detection-mode sensor reads `wanted`, since which detector is configured does
not change just because a reconnect has yet to re-arm the stream. With streaming
down no cast starts and the casting LED stays dark, rather than promising a cast
that can only fail.

**Drop in-flight casts on disconnect.** Disconnecting mid-cast left `button_all`
latched true. The wand reports buttons released while disconnected, so the next
press was not seen as a transition and no cast started; the interrupted run's
samples would also be prepended to the following cast. `_reset_cast_state()`
clears this from both disconnect paths, via a new `SpellTracker.abort()` that
discards the recording without attempting recognition.

**Log why recognition rejected a cast** (separate commit). The `-1`…`-4` error
codes all vanished at `if spell_name`. Had this been in place, the log above
would have read "not enough data points" three times instead of nothing.

**Ignore local model files** (two separate commits). `*.bak` and `*.tflite` are
hundreds of KB of binary that a stray `git add -A` would sweep into the history.
The model is served by the TFLite add-on rather than shipped with the
integration, so nothing in the repo needs to track one.

## Testing

`tests/test_spell_tracking_reconnect.py`, 20 tests covering: a reconnect resumes
streaming when tracking was on and does not when it was off; a failed resume is
logged, keeps the connection up, and does not report as tracking; and interrupted
casts do not survive a reconnect. Three drive the real `connect()` with the BLE
layer patched, rather than asserting on the wiring indirectly.

174 tests pass; `ruff check` and `ruff format --check` clean. Against `38d8013`,
the commit this branch starts from, 18 of the 20 new tests fail.

## Not verified against hardware

The diagnosis comes from a user's debug log and the tests exercise the logic
through fakes. Confirming the fix means reconnecting a real wand and casting
without touching the Spell Tracking switch.
