### PR TITLE
Fix spell tracking breaking on a quick wand reconnect

### DIFF
--- a/custom_components/magic_caster_wand/mcw_ble/parser.py
+++ b/custom_components/magic_caster_wand/mcw_ble/parser.py
@@ -317,7 +317,19 @@ class McwDevice:
             self._spell_tracker.abort()
 
     def _on_disconnect(self, client: BleakClient) -> None:
-        """Handle BLE device disconnection."""
+        """Handle BLE device disconnection.
+
+        Callbacks from a superseded connection are ignored. bleak dispatches this
+        through the event loop, so a quick reconnect can install a new client before
+        the old link's callback runs. Acting on that late callback would tear down
+        the connection that replaced it -- dropping _mcw and _imu_streaming while the
+        wand is connected and streaming, which reads as the wand being live but spell
+        tracking silently doing nothing until the switch is toggled.
+        """
+        if client is not self.client:
+            _LOGGER.debug("Ignoring disconnect callback from a superseded connection")
+            return
+
         _LOGGER.debug("Disconnected from Magic Caster Wand")
         self.client = None
         self._mcw = None
@@ -665,7 +677,16 @@ class McbDevice:
             self._coordinator_charge.async_set_updated_data(data)
 
     def _on_disconnect(self, client: BleakClient) -> None:
-        """Handle BLE device disconnection."""
+        """Handle BLE device disconnection.
+
+        Ignores callbacks from a superseded connection, for the same reason as the
+        wand: a late callback would otherwise clear _mcb and mark the box offline
+        while it is in fact connected.
+        """
+        if client is not self.client:
+            _LOGGER.debug("Ignoring disconnect callback from a superseded connection")
+            return
+
         _LOGGER.debug("Disconnected from Magic Caster Box")
         self.client = None
         self._mcb = None

--- a/tests/test_spell_tracking_reconnect.py
+++ b/tests/test_spell_tracking_reconnect.py
@@ -4,14 +4,19 @@ IMU streaming is firmware state that dies with the connection, while the detecto
 session that gates the button and IMU callbacks outlives it. These tests pin the
 two together: a reconnect must re-arm streaming when tracking was on, must not
 when it was off, and must not claim to be tracking when re-arming failed.
+
+They also cover the ordering hazard on a quick reconnect: bleak dispatches the
+disconnect callback through the event loop, so the old link's callback can arrive
+after a new connection is already up, and must not tear it down.
 """
 
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 
 from custom_components.magic_caster_wand.mcw_ble import parser
-from custom_components.magic_caster_wand.mcw_ble.parser import McwDevice
+from custom_components.magic_caster_wand.mcw_ble.parser import McbDevice, McwDevice
 
 
 class FakeClient:
@@ -313,6 +318,115 @@ def test_a_cast_works_normally_after_reconnecting():
 
     assert device._button_all_pressed is True, "the press must register as a new cast"
     assert device._spell_tracker._state.tracking_active == 1
+
+
+# ── A late disconnect callback must not tear down the new connection ─────────
+
+
+def test_superseded_disconnect_callback_is_ignored():
+    """bleak dispatches the disconnect callback through the event loop, so a quick
+    reconnect can install a new client before the old link's callback runs. Acting
+    on it then would clear the state of the connection that replaced it."""
+    device = make_device(tracking_wanted=True)
+    old_client = device.client
+    asyncio.run(device._resume_imu_streaming())
+
+    # Reconnect lands first: new client, new protocol client, streaming re-armed.
+    device.client = FakeClient()
+    device._mcw = FakeMcwClient()
+    asyncio.run(device._resume_imu_streaming())
+
+    device._on_disconnect(old_client)  # the old link's callback, arriving late
+
+    assert device.client is not None, "the live connection must survive"
+    assert device._mcw is not None, "clearing this would break buzz, LEDs and macros"
+    assert device.spell_tracking_active is True, "streaming is armed on the new link"
+
+
+def test_superseded_disconnect_callback_does_not_report_offline():
+    """The connection coordinator drives entity availability, so a stale False
+    would mark a live wand unavailable."""
+    device = make_device(tracking_wanted=True)
+    old_client = device.client
+    coordinator = MagicMock()
+    device._coordinator_connection = coordinator
+    device.client = FakeClient()
+
+    device._on_disconnect(old_client)
+
+    coordinator.async_set_updated_data.assert_not_called()
+
+
+def test_superseded_disconnect_callback_does_not_abort_a_live_cast():
+    """A cast in flight on the new connection must not be discarded by the old
+    connection's callback."""
+    device = make_device(tracking_wanted=True)
+    old_client = device.client
+    device.client = FakeClient()
+    device._mcw = FakeMcwClient()
+    asyncio.run(device._resume_imu_streaming())
+    press_all_buttons(device)
+    feed_imu(device, 5)
+
+    device._on_disconnect(old_client)
+
+    assert device._button_all_pressed is True, "the press is still held on the live link"
+    assert device._spell_tracker._state.tracking_active == 1, "the recording must stay open"
+    assert device._spell_tracker._state.position_count > 1, "samples must not be discarded"
+
+
+def test_disconnect_callback_for_the_current_client_still_applies():
+    """The guard must not swallow the real thing."""
+    device = make_device(tracking_wanted=True)
+    asyncio.run(device._resume_imu_streaming())
+
+    device._on_disconnect(device.client)
+
+    assert device.client is None
+    assert device._mcw is None
+    assert device._imu_streaming is False
+
+
+def test_disconnect_callback_after_an_explicit_disconnect_is_ignored():
+    """disconnect() clears the client, so the callback it triggers arrives with
+    self.client already None and must not be mistaken for a live connection."""
+    device = make_device(tracking_wanted=True)
+    old_client = device.client
+    coordinator = MagicMock()
+    asyncio.run(device.disconnect())
+    device._coordinator_connection = coordinator
+    device.client = FakeClient()  # a reconnect that beat the callback
+    device._mcw = FakeMcwClient()
+
+    device._on_disconnect(old_client)
+
+    assert device.client is not None
+    coordinator.async_set_updated_data.assert_not_called()
+
+
+def test_box_ignores_a_superseded_disconnect_callback():
+    """McbDevice has the identical shape and the identical exposure."""
+    device = McbDevice("AA:BB:CC:DD:EE:FF")
+    old_client = FakeClient()
+    device.client = old_client
+    device._mcb = object()
+
+    device.client = FakeClient()  # reconnected before the callback ran
+    device._on_disconnect(old_client)
+
+    assert device.client is not None
+    assert device._mcb is not None
+
+
+def test_box_disconnect_callback_for_the_current_client_still_applies():
+    device = McbDevice("AA:BB:CC:DD:EE:FF")
+    device.client = FakeClient()
+    device._mcb = object()
+
+    device._on_disconnect(device.client)
+
+    assert device.client is None
+    assert device._mcb is None
 
 
 # ── Streaming state tracks the explicit start/stop calls ─────────────────────


### PR DESCRIPTION
Reconnecting a wand quickly — roughly within a second — can leave it reporting connected while spell tracking silently does nothing, and only toggling the Spell Tracking switch recovers it.

That is the same symptom as #77, but it is reached by a different route and the fix there does not prevent it.

## Cause

`bleak` dispatches `disconnected_callback` through the event loop, so it does not necessarily run before whatever else is already queued. `_on_disconnect` took a `client` argument and ignored it, clearing state unconditionally:

```python
def _on_disconnect(self, client: BleakClient) -> None:
    self.client = None
    self._mcw = None
    self._reset_cast_state()
```

On a quick reconnect the ordering can interleave:

1. The link drops. `bleak` schedules `_on_disconnect(old_client)`.
2. A reconnect gets there first — the coordinator's `update_device`, or the Connect switch. `is_connected()` reads the stale `self.client`, whose `is_connected` may not have flipped yet. `connect()` proceeds, installs a **new** `self.client` and `self._mcw`, and `_resume_imu_streaming()` sets `_imu_streaming = True`.
3. The queued `_on_disconnect(old_client)` now runs and tears down the **new** connection's state.

After step 3 the wand is physically connected and streaming, but `spell_tracking_active` is `False`, the Spell Tracking switch reads off, and `_callback_buttons` and `_callback_imu` are both inert. Clearing `_mcw` also silently breaks `buzz`, `set_led` and macros until the next reconnect.

Two things make the window reachable at ~1s in particular. `establish_connection` retries internally and can return quickly on a warm cache, so step 2 can finish well under a second. And HA's BlueZ backend routes the disconnect through D-Bus property changes, which adds latency between the physical drop and the callback firing — a slow reconnect gives the callback time to land first, a fast one does not.

## Fix

Compare the callback's client against the current one and return early if they differ. The argument was already being passed; it was just discarded.

```python
if client is not self.client:
    _LOGGER.debug("Ignoring disconnect callback from a superseded connection")
    return
```

`McbDevice._on_disconnect` has the identical shape and the identical exposure, so it gets the same guard — there, a late callback would clear `_mcb` and mark the box offline while it is connected.

## Tests

Seven new tests in `tests/test_spell_tracking_reconnect.py` drive the interleaving directly: a superseded callback must not clear the live client, must not report the device offline through the connection coordinator, and must not abort an in-flight cast; a callback for the current client must still apply in full.

Against `93323e1`, the commit this branch starts from, **five of the seven fail**. The two that pass are the negative controls — they assert the guard does not swallow a legitimate disconnect, which is unchanged behaviour. If those had failed, the guard would be too broad.

With the fix: 181 passed, `ruff check` and `ruff format --check` both clean.

## Scope

One narrower case remains open. If the callback arrives *during* `connect()` — after `establish_connection` has returned but before `self.client` is assigned — the guard correctly ignores it, but nothing re-checks that the new link is still alive. That resolves itself on the next coordinator poll rather than needing a switch toggle, so it is a much milder failure. Closing it fully means serializing connect/disconnect behind an `asyncio.Lock`, which seemed out of proportion to the bug being fixed here; happy to add it if you would prefer.

## Not verified against hardware

This has been reasoned from the code and covered by tests, but not confirmed on a real wand. Doing so means dropping and re-establishing a connection within about a second and then casting without touching the Spell Tracking switch.
